### PR TITLE
Add number rewrites in "Simple" style

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ You can find the currently-enabled styles in the `Mix.Tasks.Style` module, insid
 
 ## Credo Rules Styler Replaces
 
-| credo rule                            | style that rewrites to suit          |
+| credo rule                            | Styler Style                         |
 |---------------------------------------|--------------------------------------|
 | `Credo.Check.Readability.AliasOrder`  | `Styler.Style.Aliases`               |
+| `Credo.Check.Readability.LargeNumbers`| `Styler.Style.Simple`                |
 | `Credo.Check.Readability.MultiAlias`  | `Styler.Style.Aliases`               |
-| `Credo.Check.Readability.UnnecessaryAliasExpansion` | `Styler.Style.Aliases` |
 | `Credo.Check.Readability.SinglePipe`  | `Styler.Style.Pipes`                 |
+| `Credo.Check.Readability.UnnecessaryAliasExpansion` | `Styler.Style.Aliases` |
 | `Credo.Check.Refactor.PipeChainStart` | `Styler.Style.Pipes`                 |
 
 ## Writing Styles

--- a/lib/style/simple.ex
+++ b/lib/style/simple.ex
@@ -15,13 +15,14 @@ defmodule Styler.Style.Simple do
   Credo Rules addressed:
 
   * Credo.Check.Readability.LargeNumbers
+      Formatter handles large number (>5 digits) rewrites, but doesn't rewrite typos like `100_000_0`, so it's worthwhile to have styler do this
   """
 
   @behaviour Styler.Style
 
   alias Styler.Zipper
 
-  # note that `?-` isn't part of the number node - it's its parent - so all numbers are positive at this point
+  # `?-` isn't part of the number node - it's its parent - so all numbers are positive at this point
   def run({{:__block__, meta, [number]}, _} = zipper) when is_number(number) and number >= 10_000 do
     # Checking here rather than in the anon function due to compiler bug https://github.com/elixir-lang/elixir/issues/10485
     integer? = is_integer(number)

--- a/test/style/simple_test.exs
+++ b/test/style/simple_test.exs
@@ -1,0 +1,46 @@
+# Copyright 2023 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+defmodule Styler.Style.SimpleTest do
+  use Styler.StyleCase, style: Styler.Style.Simple, async: true
+
+  describe "run/1" do
+    test "styles decimal floats and integers > 10k" do
+      assert_style(
+        """
+        10000
+        1_0_0_0_0
+        -54321
+        123456789
+        55333.22
+        """,
+        """
+        10_000
+        10_000
+        -54_321
+        123_456_789
+        55_333.22
+        """
+      )
+    end
+
+    test "stays away from small numbers and science" do
+      assert_style("""
+      1234
+      9999
+      "10000"
+      0xFFFF
+      0x123456
+      0b1111_1111_1111_1111
+      0o777_7777
+      """)
+    end
+  end
+end

--- a/test/style/simple_test.exs
+++ b/test/style/simple_test.exs
@@ -12,7 +12,7 @@ defmodule Styler.Style.SimpleTest do
   use Styler.StyleCase, style: Styler.Style.Simple, async: true
 
   describe "run/1" do
-    test "styles floats and integers with >5 digits" do
+    test "styles floats and integers with >4 digits" do
       assert_style(
         """
         10000

--- a/test/style/simple_test.exs
+++ b/test/style/simple_test.exs
@@ -12,26 +12,28 @@ defmodule Styler.Style.SimpleTest do
   use Styler.StyleCase, style: Styler.Style.Simple, async: true
 
   describe "run/1" do
-    test "styles decimal floats and integers > 10k" do
+    test "styles floats and integers with >5 digits" do
       assert_style(
         """
         10000
         1_0_0_0_0
-        -54321
+        -543213
         123456789
         55333.22
+        -123456728.0001
         """,
         """
         10_000
         10_000
-        -54_321
+        -543_213
         123_456_789
         55_333.22
+        -123_456_728.0001
         """
       )
     end
 
-    test "stays away from small numbers and science" do
+    test "stays away from small numbers, strings and science" do
       assert_style("""
       1234
       9999


### PR DESCRIPTION
implements a rule replacing `Credo.Check.Readability.LargeNumbers`