### PR TITLE
`mix style -`: read/write stdin/stdout like formatter

### DIFF
--- a/lib/mix/tasks/style.ex
+++ b/lib/mix/tasks/style.ex
@@ -15,6 +15,8 @@ defmodule Mix.Tasks.Style do
 
     mix style mix.exs "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}"
 
+  If `-` is one of the files, input is read from stdin and written to stdout.
+
   `mix style` uses the same options as `mix format` specified in `.formatter.exs` to
   format the code, and to determine which files to style if you don't pass any as arguments
 


### PR DESCRIPTION
Adds stdin/stdout interactions to match the formatter

```bash
➜  styler git:(me/stdin) ✗ mix format -
defmodule A do
alias C.{F, E}
alias B

alias A
end
defmodule A do
  alias C.{F, E}
  alias B

  alias A
end

➜  styler git:(me/stdin) ✗ mix style -
defmodule A do
alias C.{F, E}
alias B

alias A
end
defmodule A do
  alias B
  alias C.E
  alias C.F

  alias A
end
```