### PR TITLE
Optimize module directives, remove concept of directive groups

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -87,7 +87,7 @@ defmodule Styler.Style.ModuleDirectives do
 
       {:@, _, [{:moduledoc, _, _}]} ->
         # a module whose only child is a moduledoc. nothing to do here!
-        # seems weird at first blushm but lots of projects/libraries do this with their root namespace module
+        # seems weird at first blush but lots of projects/libraries do this with their root namespace module
         {:skip, zipper, ctx}
 
       only_child ->

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -74,8 +74,8 @@ defmodule Styler.Style.ModuleDirectives do
   @dont_moduledoc ~w(Test Mixfile MixProject Controller Endpoint Repo Router Socket View HTML JSON)
   @moduledoc_false {:@, [], [{:moduledoc, [], [{:__block__, [], [false]}]}]}
 
-  def run({{:defmodule, _, mod_args}, _} = zipper) do
-    [{_, _, aliases = _mod_name}, [{mod_do, _module_body__move_focus_here!}]] = mod_args
+  def run({{:defmodule, _, children}, _} = zipper) do
+    [{_, _, aliases} = _module_name, [{mod_do, _module_body__move_focus_here!}]] = children
     # Move the zipper's focus to the module's body
     name = aliases |> List.last() |> to_string()
     add_moduledoc? = not String.ends_with?(name, @dont_moduledoc)

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -168,7 +168,7 @@ defmodule Styler.Style.ModuleDirectives do
     |> Enum.map(&{&1, &1 |> Macro.to_string() |> String.downcase()})
     |> Enum.uniq_by(&elem(&1, 1))
     |> List.keysort(1)
-    |> Enum.map(&(&1 |> elem(0)))
+    |> Enum.map(&elem(&1, 0))
     |> reset_newlines()
   end
 

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -178,10 +178,9 @@ defmodule Styler.Style.ModuleDirectives do
     |> Enum.flat_map(&expand_directive/1)
     |> Enum.map(&{&1, &1 |> Macro.to_string() |> String.downcase()})
     |> Enum.uniq_by(&elem(&1, 1))
-    |> List.keysort(1, :desc)
+    |> List.keysort(1)
     |> Enum.map(&(&1 |> elem(0) |> set_newlines(1)))
-    |> List.update_at(0, &set_newlines(&1, 2))
-    |> Enum.reverse()
+    |> List.update_at(-1, &set_newlines(&1, 2))
   end
 
   # alias Foo.{Bar, Baz}

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -118,7 +118,7 @@ defmodule Styler.Zipper do
   Returns the zipper of the left sibling of the node at this zipper, or nil.
   """
   @spec left(zipper) :: zipper | nil
-  def left({tree, %{l: [ltree | l], r: r} = meta}), do: {ltree, %{meta | l: l, r: [tree | r || []]}}
+  def left({tree, %{l: [ltree | l], r: r} = meta}), do: {ltree, %{meta | l: l, r: [tree | r]}}
   def left(_), do: nil
 
   @doc """

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -57,12 +57,12 @@ defmodule Styler.Zipper do
   @doc """
   Returns a new branch node, given an existing node and new children.
   """
-  @spec make_node(tree, [tree]) :: tree
-  def make_node({form, meta, _}, args) when is_atom(form), do: {form, meta, args}
-  def make_node({_form, meta, args}, [first | rest]) when is_list(args), do: {first, meta, rest}
-  def make_node({_, _}, [left, right]), do: {left, right}
-  def make_node({_, _}, args), do: {:{}, [], args}
-  def make_node(list, children) when is_list(list), do: children
+  @spec replace_children(tree, [tree]) :: tree
+  def replace_children({form, meta, _}, children) when is_atom(form), do: {form, meta, children}
+  def replace_children({_form, meta, args}, [first | rest]) when is_list(args), do: {first, meta, rest}
+  def replace_children({_, _}, [left, right]), do: {left, right}
+  def replace_children({_, _}, children), do: {:{}, [], children}
+  def replace_children(list, children) when is_list(list), do: children
 
   @doc """
   Creates a zipper from a tree node.
@@ -111,7 +111,7 @@ defmodule Styler.Zipper do
   def up({tree, meta}) do
     children = Enum.reverse(meta.l, [tree | meta.r])
     {parent, parent_meta} = meta.ptree
-    {make_node(parent, children), parent_meta}
+    {replace_children(parent, children), parent_meta}
   end
 
   @doc """
@@ -170,7 +170,7 @@ defmodule Styler.Zipper do
   @spec remove(zipper) :: zipper
   def remove({_, nil}), do: raise(ArgumentError, message: "Cannot remove the top level node.")
   def remove({_, %{l: [left | rest]} = meta}), do: prev_down({left, %{meta | l: rest}})
-  def remove({_, %{ptree: {parent, parent_meta}, r: children}}), do: {make_node(parent, children), parent_meta}
+  def remove({_, %{ptree: {parent, parent_meta}, r: children}}), do: {replace_children(parent, children), parent_meta}
 
   @doc """
   Inserts the item as the left sibling of the node at this zipper, without

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -39,6 +39,10 @@ defmodule Styler.Style.ModuleDirectivesTest do
         end
 
         def Foo, do: :ok
+
+        defmodule Foo do
+          alias Foo.{Bar, Baz}
+        end
         """,
         """
         defmodule A do
@@ -69,6 +73,12 @@ defmodule Styler.Style.ModuleDirectivesTest do
         end
 
         def Foo, do: :ok
+
+        defmodule Foo do
+          @moduledoc false
+          alias Foo.Bar
+          alias Foo.Baz
+        end
         """
       )
     end

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -87,6 +87,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
       assert_style(
         """
         defmodule Foo do
+          @behaviour Lawful
           require A
           alias A
 
@@ -132,6 +133,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
                      |> String.split("<!-- MDOC !-->")
                      |> Enum.fetch!(1)
           @behaviour Chaotic
+          @behaviour Lawful
 
           use B
           use A

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -19,6 +19,11 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule A do
         end
 
+        defmodule B do
+          defmodule C do
+          end
+        end
+
         defmodule Bar do
           alias Bop
 
@@ -38,6 +43,13 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """
         defmodule A do
           @moduledoc false
+        end
+
+        defmodule B do
+          @moduledoc false
+          defmodule C do
+            @moduledoc false
+          end
         end
 
         defmodule Bar do

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -90,18 +90,34 @@ defmodule Styler.Style.ModuleDirectivesTest do
           require A
           alias A
 
+          use B
+
           def c(x), do: y
+
+          import C
           @behaviour Chaotic
+          @doc "d doc"
           def d do
             alias X
             alias H
+
+            alias Z
             import Ecto.Query
             X.foo()
           end
           @shortdoc "it's pretty short"
           import A
+          alias C
+          alias D
+
+          require C
           require B
+
           use A
+
+          alias C
+          alias A
+
           @moduledoc "README.md"
                      |> File.read!()
                      |> String.split("<!-- MDOC !-->")
@@ -117,22 +133,29 @@ defmodule Styler.Style.ModuleDirectivesTest do
                      |> Enum.fetch!(1)
           @behaviour Chaotic
 
+          use B
           use A
 
           import A
+          import C
 
           alias A
+          alias C
+          alias D
 
           require A
           require B
+          require C
 
           def c(x), do: y
 
+          @doc "d doc"
           def d do
+            import Ecto.Query
+
             alias H
             alias X
-
-            import Ecto.Query
+            alias Z
 
             X.foo()
           end
@@ -160,13 +183,12 @@ defmodule Styler.Style.ModuleDirectivesTest do
           #{d} A
           """,
           """
+          #{d} A
           #{d} A.A
           #{d} A.B
           #{d} A.C
-          #{d} D
-
-          #{d} A
           #{d} B
+          #{d} D
           """
         )
       end
@@ -175,8 +197,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
     test "expands use but does not sort it" do
       assert_style(
         """
-        use A
         use D
+        use A
         use A.{
           C,
           B
@@ -184,8 +206,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         import F
         """,
         """
-        use A
         use D
+        use A
         use A.C
         use A.B
 
@@ -197,6 +219,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
     test "interwoven directives w/o the context of a module" do
       assert_style(
         """
+        @type foo :: :ok
         alias D
         alias A.{B}
         require A.{
@@ -207,14 +230,15 @@ defmodule Styler.Style.ModuleDirectivesTest do
         alias A
         """,
         """
+        alias A
         alias A.B
+        alias B
         alias D
 
         require A.A
         require A.C
 
-        alias A
-        alias B
+        @type foo :: :ok
         """
       )
     end

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -22,9 +22,9 @@ defmodule Styler.StyleCase do
     unless style, do: raise(ArgumentError, "missing required `:style` option")
 
     quote do
-      @style unquote(style)
       import unquote(__MODULE__), only: [assert_style: 1, assert_style: 2]
 
+      @style unquote(style)
       def style(code), do: unquote(__MODULE__).style(code, @style)
     end
   end

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -45,26 +45,26 @@ defmodule StylerTest.ZipperTest do
     end
   end
 
-  describe "make_node/2" do
+  describe "replace_children/2" do
     test "2-tuples" do
-      assert Zipper.make_node({1, 2}, [3, 4]) == {3, 4}
+      assert Zipper.replace_children({1, 2}, [3, 4]) == {3, 4}
     end
 
     test "changing to 2-tuples arity" do
-      assert Zipper.make_node({1, 2}, [3, 4, 5]) == {:{}, [], [3, 4, 5]}
-      assert Zipper.make_node({1, 2}, [3]) == {:{}, [], [3]}
+      assert Zipper.replace_children({1, 2}, [3, 4, 5]) == {:{}, [], [3, 4, 5]}
+      assert Zipper.replace_children({1, 2}, [3]) == {:{}, [], [3]}
     end
 
     test "lists" do
-      assert Zipper.make_node([1, 2, 3], [:a, :b, :c]) == [:a, :b, :c]
+      assert Zipper.replace_children([1, 2, 3], [:a, :b, :c]) == [:a, :b, :c]
     end
 
     test "unqualified calls" do
-      assert Zipper.make_node({:foo, [], [1, 2]}, [:a, :b]) == {:foo, [], [:a, :b]}
+      assert Zipper.replace_children({:foo, [], [1, 2]}, [:a, :b]) == {:foo, [], [:a, :b]}
     end
 
     test "qualified calls" do
-      assert Zipper.make_node({{:., [], [1, 2]}, [], [3, 4]}, [:a, :b, :c]) == {:a, [], [:b, :c]}
+      assert Zipper.replace_children({{:., [], [1, 2]}, [], [3, 4]}, [:a, :b, :c]) == {:a, [], [:b, :c]}
     end
   end
 


### PR DESCRIPTION
Changes:

- directives: will remove newlines between groups: no more empty space between your aliases etc
- directives: orders different directives in all contexts, not just module bodies (functions, quote do, etc, will now be organized)
- rename `Zipper.make_node/2` -> `Zipper.replace_children/2`, which made it a little clearer to me what problems it can solve! 
- `@moduledoc` `@behaviour` and `@shortdoc` will not be noticed outside of a defmodule if they are alone in the context with no `use/alias/import/require`. you can see this in the implementation of run: it only catches `defmodule, use, alias, import, require`. i feel like this is.. too much of an edgecase to deal with for the moment, as it'll only occur in super weird macro situations? ala `quote do @moduledoc ...; @behaviour ...; end`

## Looking for feedback on

- whatever your heart desires!
- lmk if you have a better name for the zipper api change (`Zipper.set_children`?)