### PR TITLE
Change `Style.run` type spec to explicitly rely on `Zipper.traverse_while/3`

### DIFF
--- a/lib/style.ex
+++ b/lib/style.ex
@@ -18,7 +18,10 @@ defmodule Styler.Style do
 
   alias Styler.Zipper
 
-  @type command :: :cont | :skip | :halt
+  @type context :: %{
+          comment: [map()],
+          file: :stdin | String.t()
+        }
 
   @doc """
   `run` will be used with `Zipper.traverse_while/3`, meaning it will be executed on every node of the AST.
@@ -26,17 +29,5 @@ defmodule Styler.Style do
   You can skip traversing parts of the tree by returning a Zipper that's further along in the traversal, for example
   by calling `Zipper.skip(zipper)` to skip an entire subtree you know is of no interest to your Style.
   """
-  @callback run(Zipper.zipper()) :: Zipper.zipper() | {command(), Zipper.zipper()}
-
-  @doc false
-  # this lets Styles optionally implement as though they're running inside of `Zipper.traverse`
-  # or `Zipper.traverse_while` for finer-grained control
-  def wrap_run(style) do
-    fn zipper ->
-      case style.run(zipper) do
-        {next, {_, _} = _zipper} = command when next in ~w(cont halt skip)a -> command
-        zipper -> {:cont, zipper}
-      end
-    end
-  end
+  @callback run(Zipper.zipper(), context()) :: {Zipper.command(), Zipper.zipper(), context()}
 end

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -26,12 +26,12 @@ defmodule Styler.Style.Pipes do
   @blocks ~w(case if with cond for unless)a
 
   # we're in a multi-pipe, so only need to fix pipe_start
-  def run({{:|>, _, [{:|>, _, _} | _]}, _} = zipper), do: zipper |> check_start() |> Zipper.next()
+  def run({{:|>, _, [{:|>, _, _} | _]}, _} = zipper, ctx), do: {:cont, zipper |> check_start() |> Zipper.next(), ctx}
   # this is a single pipe, since valid pipelines are consumed by the previous head
-  def run({{:|>, meta, [lhs, {fun, _, args}]}, _} = zipper) do
+  def run({{:|>, meta, [lhs, {fun, _, args}]}, _} = zipper, ctx) do
     if valid_pipe_start?(lhs) do
       # `a |> f(b, c)` => `f(a, b, c)`
-      Zipper.replace(zipper, {fun, meta, [lhs | args]})
+      {:cont, Zipper.replace(zipper, {fun, meta, [lhs | args]}), ctx}
     else
       zipper = fix_start(zipper)
       {maybe_block, _, _} = lhs
@@ -39,16 +39,16 @@ defmodule Styler.Style.Pipes do
       if maybe_block in @blocks do
         # extracting a block means this is now `if_result |> single_pipe(a, b)`
         # recursing will give us `single_pipe(if_result, a, b)`
-        run(zipper)
+        run(zipper, ctx)
       else
         # fixing the start when it was a function call added another pipe to the chain, and so it's no longer
         # a single pipe
-        zipper
+        {:cont, zipper, ctx}
       end
     end
   end
 
-  def run(zipper), do: zipper
+  def run(zipper, ctx), do: {:cont, zipper, ctx}
 
   # walking down a pipeline.
   # for reference, `a |> b() |> c()` is encoded `{:|>, [{:|>, _, [a, b]}, c]}`

--- a/lib/style/simple.ex
+++ b/lib/style/simple.ex
@@ -23,7 +23,7 @@ defmodule Styler.Style.Simple do
   alias Styler.Zipper
 
   # `?-` isn't part of the number node - it's its parent - so all numbers are positive at this point
-  def run({{:__block__, meta, [number]}, _} = zipper) when is_number(number) and number >= 10_000 do
+  def run({{:__block__, meta, [number]}, _} = zipper, ctx) when is_number(number) and number >= 10_000 do
     # Checking here rather than in the anon function due to compiler bug https://github.com/elixir-lang/elixir/issues/10485
     integer? = is_integer(number)
 
@@ -47,10 +47,10 @@ defmodule Styler.Style.Simple do
           "#{delimit(int_token)}.#{decimals}"
       end)
 
-    Zipper.replace(zipper, {:__block__, meta, [number]})
+    {:skip, Zipper.replace(zipper, {:__block__, meta, [number]}), ctx}
   end
 
-  def run(zipper), do: zipper
+  def run(zipper, ctx), do: {:cont, zipper, ctx}
 
   defp delimit(token), do: token |> String.to_charlist() |> remove_underscores([]) |> add_underscores([])
 

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -34,6 +34,7 @@ defmodule Styler.Zipper do
           }
 
   @type zipper :: {tree, path | nil}
+  @type command :: :cont | :skip | :halt
 
   @doc """
   Returns true if the node is a branch.
@@ -313,7 +314,6 @@ defmodule Styler.Zipper do
   The function must return a zipper.
   """
   @spec traverse_while(zipper, (zipper -> {command, zipper})) :: zipper
-        when command: :cont | :halt | :skip
   def traverse_while({_tree, nil} = zipper, fun) do
     do_traverse_while(zipper, fun)
   end
@@ -341,7 +341,6 @@ defmodule Styler.Zipper do
   If the zipper is not at the top, just the subtree will be traversed.
   """
   @spec traverse_while(zipper, term, (zipper, term -> {command, zipper, term})) :: {zipper, term}
-        when command: :cont | :halt | :skip
   def traverse_while({_tree, nil} = zipper, acc, fun) do
     do_traverse_while(zipper, acc, fun)
   end

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -14,7 +14,6 @@ defmodule Styler.StyleCase do
   """
   use ExUnit.CaseTemplate
 
-  alias Styler.Style
   alias Styler.Zipper
 
   using options do
@@ -58,14 +57,13 @@ defmodule Styler.StyleCase do
   def style(code, style) do
     {ast, comments} = Styler.string_to_quoted_with_comments(code)
 
-    styled_ast =
+    {zipper, %{comments: comments}} =
       ast
       |> Zipper.zip()
-      |> Zipper.traverse_while(Style.wrap_run(style))
-      |> Zipper.root()
+      |> Zipper.traverse_while(%{comments: comments, file: "test"}, &style.run/2)
 
+    styled_ast = Zipper.root(zipper)
     styled_code = Styler.quoted_to_string(styled_ast, comments)
-
     {styled_ast, styled_code}
   end
 end


### PR DESCRIPTION
zipper traversal is now powered by `traverse_while/3`, and all styles are forced to acknowledge the new shape - no more hiding behind `wrap_run`

```elixir
  @callback run(Zipper.zipper(), context()) :: {Zipper.command(), Zipper.zipper(), context()}
```

future features are likely to work with `comments`; some may want the filename (module directives, for example) and who knows what else we'll add in. passing a map accumulator of context or state gives us a decently future-proof api