### PR TITLE
Fix Pipes Bugs

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -26,11 +26,11 @@ defmodule Styler.Style.Pipes do
   @blocks ~w(case if with cond for unless)a
 
   # we're in a multi-pipe, so only need to fix pipe_start
-  def run({{:|>, _, [{:|>, _, _} | _]}, _} = zipper, ctx), do: ({:cont, zipper |> check_start() |> Zipper.next(), ctx})
+  def run({{:|>, _, [{:|>, _, _} | _]}, _} = zipper, ctx), do: {:cont, zipper |> check_start() |> Zipper.next(), ctx}
   # this is a single pipe, since valid pipelines are consumed by the previous head
   def run({{:|>, _, [lhs, {fun, meta, args}]}, _} = zipper, ctx) do
     if valid_pipe_start?(lhs) do
-      replacement = {fun, meta, [lhs | (args || [])]}
+      replacement = {fun, meta, [lhs | args || []]}
       # `a |> f(b, c)` => `f(a, b, c)`
       {:cont, Zipper.replace(zipper, replacement), ctx}
     else

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -30,9 +30,8 @@ defmodule Styler.Style.Pipes do
   # this is a single pipe, since valid pipelines are consumed by the previous head
   def run({{:|>, _, [lhs, {fun, meta, args}]}, _} = zipper, ctx) do
     if valid_pipe_start?(lhs) do
-      replacement = {fun, meta, [lhs | args || []]}
       # `a |> f(b, c)` => `f(a, b, c)`
-      {:cont, Zipper.replace(zipper, replacement), ctx}
+      {:cont, Zipper.replace(zipper, {fun, meta, [lhs | args || []]}), ctx}
     else
       zipper = fix_start(zipper)
       {maybe_block, _, _} = lhs

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -164,7 +164,7 @@ defmodule Styler.Style.PipesTest do
       assert_style("a |> f()", "f(a)")
     end
 
-    test "recognizes `==` as a valid pipe star" do
+    test "recognizes `==` as a valid pipe start" do
       assert_style("(bar() == 1) |> foo()", "foo(bar() == 1)")
     end
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -132,7 +132,7 @@ defmodule Styler.Style.PipesTest do
     end
   end
 
-  describe "run on single pipe + start issues" do
+  describe "single pipe + start issues" do
     test "anon functio is finen" do
       assert_style("""
       fn
@@ -159,9 +159,17 @@ defmodule Styler.Style.PipesTest do
     end
   end
 
-  describe "run on single pipe issues" do
+  describe "single pipe issues" do
     test "fixes single pipe" do
       assert_style("a |> f()", "f(a)")
+    end
+
+    test "recognizes `==` as a valid pipe star" do
+      assert_style "(bar() == 1) |> foo()", "foo(bar() == 1)"
+    end
+
+    test "handles 1-arity functions written without parens" do
+      assert_style("x |> bar", "bar(x)")
     end
 
     test "fixes single pipe in function head" do

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -165,7 +165,7 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "recognizes `==` as a valid pipe star" do
-      assert_style "(bar() == 1) |> foo()", "foo(bar() == 1)"
+      assert_style("(bar() == 1) |> foo()", "foo(bar() == 1)")
     end
 
     test "handles 1-arity functions written without parens" do

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -66,7 +66,13 @@ defmodule Styler.StyleCase do
       |> Zipper.traverse_while(%{comments: comments, file: "test"}, &style.run/2)
 
     styled_ast = Zipper.root(zipper)
-    styled_code = Styler.quoted_to_string(styled_ast, comments)
-    {styled_ast, styled_code, comments}
+    try do
+      styled_code = Styler.quoted_to_string(styled_ast, comments)
+      {styled_ast, styled_code, comments}
+    rescue
+      exception ->
+        IO.inspect styled_ast, label: [IO.ANSI.red(), "**Style created invalid ast:**", IO.ANSI.light_red()]
+        reraise exception, __STACKTRACE__
+    end
   end
 end

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -66,12 +66,13 @@ defmodule Styler.StyleCase do
       |> Zipper.traverse_while(%{comments: comments, file: "test"}, &style.run/2)
 
     styled_ast = Zipper.root(zipper)
+
     try do
       styled_code = Styler.quoted_to_string(styled_ast, comments)
       {styled_ast, styled_code, comments}
     rescue
       exception ->
-        IO.inspect styled_ast, label: [IO.ANSI.red(), "**Style created invalid ast:**", IO.ANSI.light_red()]
+        IO.inspect(styled_ast, label: [IO.ANSI.red(), "**Style created invalid ast:**", IO.ANSI.light_red()])
         reraise exception, __STACKTRACE__
     end
   end


### PR DESCRIPTION
Closes #15 

- `a |> b` created invalid ast due to `b` having ast `{:b, _meta, nil = _args}`, causing us to create the improper list `[a | nil]`
- `==` was mistakenly not included in the list of math/comparison operators that are valid starts to a pipe

also snuck in another QOL improvement for helping show invalid AST when running tests