### PR TITLE
Bugfix: Keep another set of single-pipe rewrites on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+### Fixes
+
+* `Pipes` tries even harder to keep single-pipe rewrites of invocations on one line
+
 ## v0.3.1
 
 ### Fixes

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -30,6 +30,8 @@ defmodule Styler.Style.Pipes do
   # this is a single pipe, since valid pipelines are consumed by the previous head
   def run({{:|>, _, [lhs, {fun, meta, args}]}, _} = zipper, ctx) do
     if valid_pipe_start?(lhs) do
+      # Set the lhs to be on the same line as the pipe - keeps the formatter from making a multiline invocation
+      lhs = Macro.update_meta(lhs, &Keyword.replace(&1, :line, meta[:line]))
       # `a |> f(b, c)` => `f(a, b, c)`
       {:cont, Zipper.replace(zipper, {fun, meta, [lhs | args || []]}), ctx}
     else

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -193,6 +193,31 @@ defmodule Styler.Style.PipesTest do
         bar(foo, baz, bop, boom)
         """
       )
+
+      assert_style(
+        """
+        foo
+        |> bar(baz)
+        """,
+        """
+        bar(foo, baz)
+        """
+      )
+
+      assert_style(
+        """
+        if true do false end
+        |> foo(bar)
+        """,
+        """
+        if_result =
+          if true do
+            false
+          end
+
+        foo(if_result, bar)
+        """
+      )
     end
 
     test "extracts blocks successfully" do

--- a/test/style/simple_test.exs
+++ b/test/style/simple_test.exs
@@ -11,7 +11,7 @@
 defmodule Styler.Style.SimpleTest do
   use Styler.StyleCase, style: Styler.Style.Simple, async: true
 
-  describe "run/1" do
+  describe "numbers" do
     test "styles floats and integers with >4 digits" do
       assert_style(
         """


### PR DESCRIPTION
don't know what's different about 1 vs n args but formatter was multilining this case. created a fix that should handle AllTheThings