### PR TITLE
`Pipes`: `Enum`-optimizing rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## main
 
+### Improvements
+
+* `Pipes` rewrites some two-step processes into one, fixing these credo issues in pipe chains:
+    * `Credo.Check.Refactor.FilterCount`
+    * `Credo.Check.Refactor.MapJoin`
+    * `Credo.Check.Refactor.MapInto`
+
 ### Fixes
 
 * `Pipes` tries even harder to keep single-pipe rewrites of invocations on one line

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ You can find the currently-enabled styles in the `Mix.Tasks.Style` module, insid
 | `Credo.Check.Readability.StrictModuleLayout`         | `Styler.Style.ModuleDirectives`      | potentially destructive! (see moduledoc) |
 | `Credo.Check.Readability.UnnecessaryAliasExpansion`  | `Styler.Style.ModuleDirectives`      | |
 | `Credo.Check.Refactor.PipeChainStart`                | `Styler.Style.Pipes`                 | |
+| `Credo.Check.Refactor.FilterCount`                | `Styler.Style.Pipes`                 | (in pipes only) |
+| `Credo.Check.Refactor.MapJoin`                | `Styler.Style.Pipes`                 | (in pipes only) |
 
 If you're using Credo and Styler, we recommend disabling these rules in Credo to save on unnecessary checks in CI.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can find the currently-enabled styles in the `Mix.Tasks.Style` module, insid
 | `Credo.Check.Refactor.PipeChainStart`                | `Styler.Style.Pipes`                 | |
 | `Credo.Check.Refactor.FilterCount`                | `Styler.Style.Pipes`                 | (in pipes only) |
 | `Credo.Check.Refactor.MapJoin`                | `Styler.Style.Pipes`                 | (in pipes only) |
+| `Credo.Check.Refactor.MapInto`                | `Styler.Style.Pipes`                 | (in pipes only) |
 
 If you're using Credo and Styler, we recommend disabling these rules in Credo to save on unnecessary checks in CI.
 

--- a/lib/style.ex
+++ b/lib/style.ex
@@ -32,6 +32,31 @@ defmodule Styler.Style do
   @callback run(Zipper.zipper(), context()) :: {Zipper.command(), Zipper.zipper(), context()}
 
   @doc """
+  Deletes `:line` from the node's meta
+
+  If you expected `{:foo, foo_meta, [bar, baz, bop]` to give you a a single line like
+
+    foo(bar, baz, bop)
+
+  but instead got
+
+    foo(
+      bar,
+      baz,
+      bop
+    )
+
+  then it's likely that at least one of `bar`, `baz`, and/or `bop` have `:line` meta that's confusing the formatter
+  and causing the multilining.
+
+  This function fixes that problem.
+
+    {:foo, foo_meta, Enum.map([bar, baz, bop], &Styler.Style.delete_line_meta/1)}
+    # => foo(bar, baz, bop)
+  """
+  def delete_line_meta(ast_node), do: Macro.update_meta(ast_node, &Keyword.delete(&1, :line))
+
+  @doc """
   Set the line of all comments with `line` in `range_start..range_end` to instead have line `range_start`
   """
   def displace_comments(comments, range) do

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -37,7 +37,7 @@ defmodule Styler.Style.Pipes do
       if valid_pipe_start?(lhs) do
         zipper
       else
-        {lhs_rewrite, new_assignment} = fix_start(lhs)
+        {lhs_rewrite, new_assignment} = extract_start(lhs)
 
         {pipe, _} =
           start_zipper
@@ -80,19 +80,19 @@ defmodule Styler.Style.Pipes do
   #
   # block_result
   # |> ...
-  defp fix_start({block, _, _} = lhs) when block in @blocks do
+  defp extract_start({block, _, _} = lhs) when block in @blocks do
     variable = {:"#{block}_result", [], nil}
     new_assignment = {:=, [], [variable, lhs]}
     {variable, new_assignment}
   end
 
   # `Module.foo(a, ...) |> ...` => `a |> Module.foo(...) |> ...`
-  defp fix_start({{:., dot_meta, dot_args}, args_meta, [arg | args]}) do
+  defp extract_start({{:., dot_meta, dot_args}, args_meta, [arg | args]}) do
     {{:|>, args_meta, [arg, {{:., [], dot_args}, dot_meta, args}]}, nil}
   end
 
   # `foo(a, ...) |> ...` => `a |> foo(...) |> ...`
-  defp fix_start({fun, meta, [arg | args]}), do: {{:|>, [], [arg, {fun, meta, args}]}, nil}
+  defp extract_start({fun, meta, [arg | args]}), do: {{:|>, [], [arg, {fun, meta, args}]}, nil}
 
   defp collapse_single_pipe({{:|>, _, [{:|>, _, _} | _]}, _} = zipper), do: zipper
   # `a |> f(b, c)` => `f(a, b, c)`

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -100,11 +100,6 @@ defmodule Styler.Style.Pipes do
     {variable, new_assignment}
   end
 
-  # `Module.foo(a, ...) |> ...` => `a |> Module.foo(...) |> ...`
-  defp extract_start({{:., dot_meta, dot_args}, args_meta, [arg | args]}) do
-    {{:|>, args_meta, [arg, {{:., [], dot_args}, dot_meta, args}]}, nil}
-  end
-
   # `foo(a, ...) |> ...` => `a |> foo(...) |> ...`
   defp extract_start({fun, meta, [arg | args]}), do: {{:|>, [], [arg, {fun, meta, args}]}, nil}
 

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -152,7 +152,7 @@ defmodule Styler.Style.Pipes do
     rhs =
       if empty_map?(collectable),
         do: {{:., [], [{:__aliases__, [], [:Map]}, :new]}, [], [mapper]},
-        else: {into, [], [collectable, mapper]}
+        else: {into, [], [Style.delete_line_meta(collectable), mapper]}
 
     {:|>, [], [lhs, rhs]}
   end

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -81,8 +81,7 @@ defmodule Styler.Style.Pipes do
   defp find_pipe_start(zipper) do
     Zipper.find(zipper, fn
       {:|>, _, [{:|>, _, _}, _]} -> false
-      # Possibly not a pipe after all our rewrites
-      _ -> true
+      {:|>, _, [_, _]} -> true
     end)
   end
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -60,6 +60,17 @@ defmodule Styler.Style.PipesTest do
         """
       )
     end
+
+    test "map/join" do
+      assert_style """
+      ["a", "b", "c"]
+      |> Enum.map(&String.upcase/1)
+      |> Enum.join(", ")
+      """,
+      """
+      Enum.map_join(["a", "b", "c"], ", ", &String.upcase/1)
+      """
+    end
   end
 
   describe "block starts" do

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -16,13 +16,13 @@ defmodule Styler.Style.PipesTest do
       assert_style(
         """
         a
-        |> Enum.filter(fn x -> !! x end)
+        |> Enum.filter(fun)
         |> Enum.count()
         |> IO.puts()
         """,
         """
         a
-        |> Enum.count(fn x -> !!x end)
+        |> Enum.count(fun)
         |> IO.puts()
         """
       )
@@ -30,11 +30,11 @@ defmodule Styler.Style.PipesTest do
       assert_style(
         """
         a
-        |> Enum.filter(fn x -> !! x end)
+        |> Enum.filter(fun)
         |> Enum.count()
         """,
         """
-        Enum.count(a, fn x -> !!x end)
+        Enum.count(a, fun)
         """
       )
 
@@ -64,12 +64,12 @@ defmodule Styler.Style.PipesTest do
     test "map/join" do
       assert_style(
         """
-        ["a", "b", "c"]
-        |> Enum.map(&String.upcase/1)
-        |> Enum.join(", ")
+        a
+        |> Enum.map(b)
+        |> Enum.join("|")
         """,
         """
-        Enum.map_join(["a", "b", "c"], ", ", &String.upcase/1)
+        Enum.map_join(a, "|", b)
         """
       )
     end
@@ -77,26 +77,26 @@ defmodule Styler.Style.PipesTest do
     test "map/into" do
       assert_style(
         """
-        [:a, :b, :c]
-        |> Enum.map(&({&1, to_string(&1)}))
+        a
+        |> Enum.map(b)
         |> Enum.into(%{})
         """,
-        "Map.new([:a, :b, :c], &{&1, to_string(&1)})"
+        "Map.new(a, b)"
       )
 
       assert_style(
         """
-        [:a, :b, :c]
-        |> Enum.map(&({&1, to_string(&1)}))
+        a
+        |> Enum.map(b)
         |> Enum.into(Map.new())
         """,
-        "Map.new([:a, :b, :c], &{&1, to_string(&1)})"
+        "Map.new(a, b)"
       )
 
       assert_style("""
-      [:a, :b, :c]
-      |> Enum.map(&{&1, to_string(&1)})
-      |> Enum.into(%{}, & &1)
+      a
+      |> Enum.map(b)
+      |> Enum.into(%{}, c)
       """)
     end
   end

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -74,6 +74,27 @@ defmodule Styler.Style.PipesTest do
   end
 
   describe "block starts" do
+    test "variable assignment of a block" do
+      assert_style """
+      x =
+        case y do
+          :ok -> :ok
+        end
+        |> bar()
+        |> baz()
+      """,
+      """
+      case_result =
+        case y do
+          :ok -> :ok
+        end
+
+      x =
+        case_result
+        |> bar()
+        |> baz()
+      """
+    end
     test "rewrites fors" do
       assert_style(
         """

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -116,6 +116,21 @@ defmodule Styler.Style.PipesTest do
         """,
         "Enum.into(a, %{some: :existing_map}, b)"
       )
+
+      assert_style(
+        """
+        a_multiline_mapper
+        |> Enum.map(fn %{gets: shrunk, down: to_a_more_reasonable} ->
+          {shrunk, to_a_more_reasonable}
+        end)
+        |> Enum.into(size)
+        """,
+        """
+        Enum.into(a_multiline_mapper, size, fn %{gets: shrunk, down: to_a_more_reasonable} ->
+          {shrunk, to_a_more_reasonable}
+        end)
+        """
+      )
     end
   end
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -73,6 +73,32 @@ defmodule Styler.Style.PipesTest do
         """
       )
     end
+
+    test "map/into" do
+      assert_style(
+        """
+        [:a, :b, :c]
+        |> Enum.map(&({&1, to_string(&1)}))
+        |> Enum.into(%{})
+        """,
+        "Map.new([:a, :b, :c], &{&1, to_string(&1)})"
+      )
+
+      assert_style(
+        """
+        [:a, :b, :c]
+        |> Enum.map(&({&1, to_string(&1)}))
+        |> Enum.into(Map.new())
+        """,
+        "Map.new([:a, :b, :c], &{&1, to_string(&1)})"
+      )
+
+      assert_style("""
+      [:a, :b, :c]
+      |> Enum.map(&{&1, to_string(&1)})
+      |> Enum.into(%{}, & &1)
+      """)
+    end
   end
 
   describe "block starts" do

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -98,6 +98,24 @@ defmodule Styler.Style.PipesTest do
       |> Enum.map(b)
       |> Enum.into(%{}, c)
       """)
+
+      assert_style(
+        """
+        a
+        |> Enum.map(b)
+        |> Enum.into(my_map)
+        """,
+        "Enum.into(a, my_map, b)"
+      )
+
+      assert_style(
+        """
+        a
+        |> Enum.map(b)
+        |> Enum.into(%{some: :existing_map})
+        """,
+        "Enum.into(a, %{some: :existing_map}, b)"
+      )
     end
   end
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -62,39 +62,44 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "map/join" do
-      assert_style """
-      ["a", "b", "c"]
-      |> Enum.map(&String.upcase/1)
-      |> Enum.join(", ")
-      """,
-      """
-      Enum.map_join(["a", "b", "c"], ", ", &String.upcase/1)
-      """
+      assert_style(
+        """
+        ["a", "b", "c"]
+        |> Enum.map(&String.upcase/1)
+        |> Enum.join(", ")
+        """,
+        """
+        Enum.map_join(["a", "b", "c"], ", ", &String.upcase/1)
+        """
+      )
     end
   end
 
   describe "block starts" do
     test "variable assignment of a block" do
-      assert_style """
-      x =
-        case y do
-          :ok -> :ok
-        end
-        |> bar()
-        |> baz()
-      """,
-      """
-      case_result =
-        case y do
-          :ok -> :ok
-        end
+      assert_style(
+        """
+        x =
+          case y do
+            :ok -> :ok |> IO.puts()
+          end
+          |> bar()
+          |> baz()
+        """,
+        """
+        case_result =
+          case y do
+            :ok -> IO.puts(:ok)
+          end
 
-      x =
-        case_result
-        |> bar()
-        |> baz()
-      """
+        x =
+          case_result
+          |> bar()
+          |> baz()
+        """
+      )
     end
+
     test "rewrites fors" do
       assert_style(
         """


### PR DESCRIPTION
See changelog! =)

Like with moduledirectives, as every pipe now had to have the same code run on it, it made sense to rewrite pipes to have a single entry point that step-by-step handled all the cases. I hope that the result is a more immediately-followable algorithm with less fanciness happening than before

Please lemme know where we need comments! It's all so fresh in my head right now that it seems fine as-is ;)

As I was doing these rewrites, I imagined places that our pipes rule was already failing + added tests for those as well. So this probably fixed bugs we didn't know we had along the way ^.^