### PR TITLE
Pipes: rewrite Enum.into oneliners to use Map.new instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## main
 
+## V0.4.1
+
+* `Pipes` rewrites `|> Enum.into(%{}[, mapper])` and `Enum.into(Map.new()[, mapper])` to `Map.new/1,2` calls
+
 ## v0.4.0
 
 ### Improvements
+
 
 * `Pipes` rewrites some two-step processes into one, fixing these credo issues in pipe chains:
     * `Credo.Check.Refactor.FilterCount`

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -157,6 +157,16 @@ defmodule Styler.Style.Pipes do
     {:|>, [], [lhs, rhs]}
   end
 
+  defp optimize({:|>, meta, [lhs, {{:., dm, [{_, _, [:Enum]}, :into]}, _, [collectable]}]} = node) do
+    if empty_map?(collectable), do: {:|>, meta, [lhs, {{:., dm, [{:__aliases__, [], [:Map]}, :new]}, [], []}]}, else: node
+  end
+
+  defp optimize({:|>, meta, [lhs, {{:., dm, [{_, _, [:Enum]}, :into]}, _, [collectable, mapper]}]} = node) do
+    if empty_map?(collectable),
+      do: {:|>, meta, [lhs, {{:., dm, [{:__aliases__, [], [:Map]}, :new]}, [], [Style.delete_line_meta(mapper)]}]},
+      else: node
+  end
+
   defp optimize(node), do: node
 
   defp empty_map?({:%{}, _, []}), do: true

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -93,12 +93,6 @@ defmodule Styler.Style.PipesTest do
         "Map.new(a, b)"
       )
 
-      assert_style("""
-      a
-      |> Enum.map(b)
-      |> Enum.into(%{}, c)
-      """)
-
       assert_style(
         """
         a
@@ -131,6 +125,37 @@ defmodule Styler.Style.PipesTest do
         end)
         """
       )
+    end
+
+    test "into a new map" do
+      assert_style "a |> Enum.into(foo) |> b()"
+      assert_style "a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()"
+      assert_style "a |> Enum.into(Map.new) |> b()", "a |> Map.new() |> b()"
+
+      assert_style "a |> Enum.into(foo, mapper) |> b()"
+      assert_style "a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()"
+      assert_style "a |> Enum.into(Map.new, mapper) |> b()", "a |> Map.new(mapper) |> b()"
+
+      assert_style("""
+      a
+      |> Enum.map(b)
+      |> Enum.into(%{}, c)
+      """, """
+      a
+      |> Enum.map(b)
+      |> Map.new(c)
+      """)
+
+      assert_style("""
+      a
+      |> Enum.map(b)
+      |> Enum.into(Map.new, c)
+      """, """
+      a
+      |> Enum.map(b)
+      |> Map.new(c)
+      """)
+
     end
   end
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -128,34 +128,39 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "into a new map" do
-      assert_style "a |> Enum.into(foo) |> b()"
-      assert_style "a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()"
-      assert_style "a |> Enum.into(Map.new) |> b()", "a |> Map.new() |> b()"
+      assert_style("a |> Enum.into(foo) |> b()")
+      assert_style("a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()")
+      assert_style("a |> Enum.into(Map.new) |> b()", "a |> Map.new() |> b()")
 
-      assert_style "a |> Enum.into(foo, mapper) |> b()"
-      assert_style "a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()"
-      assert_style "a |> Enum.into(Map.new, mapper) |> b()", "a |> Map.new(mapper) |> b()"
+      assert_style("a |> Enum.into(foo, mapper) |> b()")
+      assert_style("a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()")
+      assert_style("a |> Enum.into(Map.new, mapper) |> b()", "a |> Map.new(mapper) |> b()")
 
-      assert_style("""
-      a
-      |> Enum.map(b)
-      |> Enum.into(%{}, c)
-      """, """
-      a
-      |> Enum.map(b)
-      |> Map.new(c)
-      """)
+      assert_style(
+        """
+        a
+        |> Enum.map(b)
+        |> Enum.into(%{}, c)
+        """,
+        """
+        a
+        |> Enum.map(b)
+        |> Map.new(c)
+        """
+      )
 
-      assert_style("""
-      a
-      |> Enum.map(b)
-      |> Enum.into(Map.new, c)
-      """, """
-      a
-      |> Enum.map(b)
-      |> Map.new(c)
-      """)
-
+      assert_style(
+        """
+        a
+        |> Enum.map(b)
+        |> Enum.into(Map.new, c)
+        """,
+        """
+        a
+        |> Enum.map(b)
+        |> Map.new(c)
+        """
+      )
     end
   end
 


### PR DESCRIPTION
Realized we might as well ship it for all cases, not just when `Enum.map` comes ahead of it!