### PR TITLE
Bug: include Ecto.Query.from as a valid pipe start

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -179,6 +179,8 @@ defmodule Styler.Style.Pipes do
   defp valid_pipe_start?({:unquote, _, _}), do: true
   # ecto
   defp valid_pipe_start?({:from, _, _}), do: true
+  defp valid_pipe_start?({{:., _, [{_, _, [:Query]}, :from]}, _, _}), do: true
+  defp valid_pipe_start?({{:., _, [{_, _, [:Ecto, :Query]}, :from]}, _, _}), do: true
   # most of these values were lifted directly from credo's pipe_chain_start.ex
   @value_constructors ~w(% %{} .. <<>> @ {} & fn)a
   @simple_operators ~w(++ -- && ||)a

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -473,11 +473,13 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "allows ecto's from" do
-      assert_style("""
-      from(foo in Bar, where: foo.bool)
-      |> some_query_helper()
-      |> Repo.all()
-      """)
+      for from <- ~w(from Query.from Ecto.Query.from) do
+        assert_style("""
+        #{from}(foo in Bar, where: foo.bool)
+        |> some_query_helper()
+        |> Repo.all()
+        """)
+      end
     end
 
     test "extracts >0 arity functions" do


### PR DESCRIPTION
Closes #24

This error makes me think that it's likely that other macro DSLs will work poorly with the pipes op, but we'll see what crops up