### PR TITLE
Fix aliases using __MODULE__

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -193,8 +193,11 @@ defmodule Styler.Style.ModuleDirectives do
   # =>
   # alias Foo.Bar
   # alias Foo.Baz
-  defp expand_directive({directive, _, [{{:., _, [{_, _, module}, :{}]}, _, right}]}),
-    do: Enum.map(right, fn {_, meta, segments} -> {directive, meta, [{:__aliases__, [], module ++ segments}]} end)
+  defp expand_directive({directive, _, [{{:., _, [{_, _, module}, :{}]}, _, right}]}) do
+    Enum.map(right, fn {_, meta, segments} ->
+      {directive, meta, [{:__aliases__, [], (module || [:__MODULE_]) ++ segments}]}
+    end)
+  end
 
   defp expand_directive(other), do: [other]
 

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -46,6 +46,22 @@ defmodule Styler.Style.ModuleDirectivesTest do
       )
     end
 
+    test "handles aliases using __MODULE__" do
+      assert_style(
+        """
+        defmodule ATest do
+          alias __MODULE_.{A, B}
+        end
+        """,
+        """
+        defmodule ATest do
+          alias __MODULE_.A
+          alias __MODULE_.B
+        end
+        """
+      )
+    end
+
     test "adds moduledoc" do
       assert_style(
         """


### PR DESCRIPTION
This fixes an error that occurs when formatting a module with an alias on its submodules:

```elixir
defmodule Test do
  alias __MODULE_.{A, B}
end
```