### PR TITLE
Better error handling: Skip failed styles but still format files

### DIFF
--- a/lib/mix/tasks/style.ex
+++ b/lib/mix/tasks/style.ex
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Style do
         do: IO.stream() |> Enum.to_list() |> IO.iodata_to_binary(),
         else: file |> File.read!() |> String.trim()
 
-    styled = Styler.format(input, formatter_opts)
+    styled = Styler.format(input, formatter_opts, on_error: :raise)
     changed? = input != styled
 
     cond do

--- a/lib/style_error.ex
+++ b/lib/style_error.ex
@@ -15,6 +15,13 @@ defmodule Styler.StyleError do
   defexception [:exception, :style, :file]
 
   def message(%{exception: exception, style: style, file: file}) do
-    "Error running style #{style} on #{file}\n#{Exception.format_banner(:error, exception)}"
+    file = file && if file == :std, do: "stdin", else: Path.relative_to_cwd(file)
+    style = style |> Module.split() |> List.last()
+
+    """
+    Error running style #{style} on #{file}
+       Please consider opening an issue at: #{IO.ANSI.light_green()}https://github.com/adobe/elixir-styler/issues/new#{IO.ANSI.reset()}
+    #{IO.ANSI.default_color()}#{Exception.format(:error, exception)}
+    """
   end
 end


### PR DESCRIPTION
The idea is, bugs in Styler shouldn't cause folks' CI to fail.

- styles which raise during `mix format` will now just be skipped, instead of halting all other styles + formatting on that file
- `mix style` still fails as before
- asks folks to raise an issue when they encounter an error

**`mix format` example**
<img width="867" alt="Screen Shot 2023-05-06 at 8 26 24 AM" src="https://user-images.githubusercontent.com/1207005/236630145-5c38f647-eccd-405c-9789-66526e711c5c.png">

**`mix style` example**
<img width="859" alt="Screen Shot 2023-05-06 at 8 25 43 AM" src="https://user-images.githubusercontent.com/1207005/236630115-e65b6224-b5f3-460f-a07e-9096ee8ff881.png">
