### PR TITLE
spike: run all styles in a single pass

### DIFF
--- a/lib/style.ex
+++ b/lib/style.ex
@@ -105,6 +105,17 @@ defmodule Styler.Style do
   # give it a block parent, then step back to the child - we can insert next to it now that it's in a block
   defp wrap_in_block(zipper), do: zipper |> Zipper.update(&{:__block__, [], [&1]}) |> Zipper.down()
 
+  @doc "Moves all pattern matching in a tree to have the variable on the right side of all pattern matches"
+  def put_matches_on_right(ast) do
+    ast
+    |> Zipper.zip()
+    |> Zipper.traverse(fn
+      {{:=, m, [{_, _, nil} = var, match]}, _} = zipper -> Zipper.replace(zipper, {:=, m, [match, var]})
+      zipper -> zipper
+    end)
+    |> Zipper.node()
+  end
+
   @doc """
   Set the line of all comments with `line` in `range_start..range_end` to instead have line `range_start`
   """

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -95,6 +95,9 @@ defmodule Styler.Style.Pipes do
   # block_result
   # |> ...
   defp extract_start({block, _, _} = lhs) when block in @blocks do
+    #@TODO create a block style and call that? keep style open so we can call it w/ a single ast node?
+    {:cont, {{block, _, _} = lhs, _}, _} = Styler.Style.SingleNode.run({lhs, nil}, %{})
+
     variable = {:"#{block}_result", [], nil}
     new_assignment = {:=, [], [variable, lhs]}
     {variable, new_assignment}

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -17,13 +17,12 @@ defmodule Styler.Style.SingleNode do
   * Credo.Check.Consistency.ParameterPatternMatching
   * Credo.Check.Readability.LargeNumbers
   * Credo.Check.Readability.ParenthesesOnZeroArityDefs
-  * Credo.Check.Readability.PreferImplicitTry
   * Credo.Check.Refactor.CaseTrivialMatches
   """
 
   @behaviour Styler.Style
 
-  alias Styler.Zipper
+  alias Styler.Style
 
   def run({node, meta}, ctx), do: {:cont, {style(node), meta}, ctx}
 
@@ -74,19 +73,6 @@ defmodule Styler.Style.SingleNode do
     {:__block__, meta, [number]}
   end
 
-  # Remove parens from 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
-  defp style({def, dm, [{fun, funm, []} | rest]}) when def in ~w(def defp)a,
-    do: style({def, dm, [{fun, funm, nil} | rest]})
-
-  # `Credo.Check.Readability.PreferImplicitTry`
-  defp style({def, dm, [head, [{_, {:try, _, [try_children]}}]]}) when def in ~w(def defp)a,
-    do: style({def, dm, [head, try_children]})
-
-  defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a,
-    do: {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}
-
-  # defp style({:->, m, [match | rest]}), do: {:->, m, [put_matches_on_right(match) | rest]}
-
   # `Enum.reverse(foo) ++ bar` => `Enum.reverse(foo, bar)`
   defp style({:++, _, [{{:., _, [{_, _, [:Enum]}, :reverse]} = reverse, r_meta, [lhs]}, rhs]}),
     do: {reverse, r_meta, [lhs, rhs]}
@@ -100,23 +86,14 @@ defmodule Styler.Style.SingleNode do
   defp style(trivial_case(head, {:__block__, _, [true]}, do_body, {:_, _, _}, else_body)),
     do: if_ast(head, do_body, else_body)
 
-  defp style({:case, cm, [head, [{do_block, arrows}]]}), do: {:case, cm, [head, [{do_block, r_align_matches(arrows)}]]}
+  defp style({:case, cm, [head, [{do_block, arrows}]]}), do: {:case, cm, [head, [{do_block, right_align_arrows(arrows)}]]}
 
-  defp style({:fn, m, arrows}), do: {:fn, m, r_align_matches(arrows)}
+  defp style({:fn, m, arrows}), do: {:fn, m, right_align_arrows(arrows)}
 
   defp style(node), do: node
 
-  defp r_align_matches(arrows),
-    do: Enum.map(arrows, fn {:->, m, [lhs, rhs]} -> {:->, m, [put_matches_on_right(lhs), rhs]} end)
-
-  defp put_matches_on_right(ast) do
-    ast
-    |> Zipper.zip()
-    |> Zipper.traverse(fn
-      {{:=, m, [{_, _, nil} = var, match]}, _} = zipper -> Zipper.replace(zipper, {:=, m, [match, var]})
-      zipper -> zipper
-    end)
-    |> Zipper.node()
+  defp right_align_arrows(arrows) do
+    Enum.map(arrows, fn {:->, m, [lhs, rhs]} -> {:->, m, [Style.put_matches_on_right(lhs), rhs]} end)
   end
 
   # don't write an else clause if it's `false -> nil`

--- a/lib/style_error.ex
+++ b/lib/style_error.ex
@@ -12,14 +12,13 @@ defmodule Styler.StyleError do
   @moduledoc """
   Wraps errors raised by Styles during tree traversal.
   """
-  defexception [:exception, :style, :file]
+  defexception [:exception, :file]
 
-  def message(%{exception: exception, style: style, file: file}) do
+  def message(%{exception: exception, file: file}) do
     file = file && if file == :std, do: "stdin", else: Path.relative_to_cwd(file)
-    style = style |> Module.split() |> List.last()
 
     """
-    Error running style #{style} on #{file}
+    Error styling #{file}
        Please consider opening an issue at: #{IO.ANSI.light_green()}https://github.com/adobe/elixir-styler/issues/new#{IO.ANSI.reset()}
     #{IO.ANSI.default_color()}#{Exception.format(:error, exception)}
     """

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -12,6 +12,26 @@ defmodule Styler.Style.PipesTest do
   use Styler.StyleCase, async: true
 
   describe "big picture" do
+    test "case pipe" do
+      assert_style """
+      case foo do
+        true -> :ok
+        false -> :error
+      end
+      |> pipe()
+      """,
+      """
+      if_result =
+        if foo do
+          :ok
+        else
+          :error
+        end
+
+      pipe(if_result)
+      """
+    end
+
     test "doesn't modify valid pipe" do
       assert_style("""
       a()


### PR DESCRIPTION
I'll need to run this against a very large unstyled codebase to make sure it holds up. There's gotta be _some_ benefit to cutting our traversals down to a single pass :) Just a question of whether or not we need to run rules in a specific order (seems like no?)