### PR TITLE
Fix toggle state from RHS match when `var = _ ->`

### DIFF
--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -121,6 +121,9 @@ defmodule Styler.Style.SingleNode do
     ast
     |> Zipper.zip()
     |> Zipper.traverse(fn
+      # a variable equals a variable, like `_ = bar`. it's silly that people would write this, but if we don't
+      # ignore it we'll do the swap every time we run format again
+      {{:=, _, [{_, _, nil}, {_, _, nil}]}, _} = zipper -> zipper
       {{:=, m, [{_, _, nil} = var, match]}, _} = zipper -> Zipper.replace(zipper, {:=, m, [match, var]})
       zipper -> zipper
     end)

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -113,6 +113,23 @@ defmodule Styler.Style.SingleNodeTest do
         """
       )
     end
+    test "when a match is equal to a match because who knows why" do
+      assert_style(
+      """
+      case foo do
+        _ = bar -> :ok
+      end
+      """
+      )
+
+      assert_style(
+      """
+      case foo do
+        bar = _ -> :ok
+      end
+      """
+      )
+    end
 
     test "defs" do
       assert_style(

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -113,22 +113,19 @@ defmodule Styler.Style.SingleNodeTest do
         """
       )
     end
+
     test "when a match is equal to a match because who knows why" do
-      assert_style(
-      """
+      assert_style("""
       case foo do
         _ = bar -> :ok
       end
-      """
-      )
+      """)
 
-      assert_style(
-      """
+      assert_style("""
       case foo do
         bar = _ -> :ok
       end
-      """
-      )
+      """)
     end
 
     test "defs" do


### PR DESCRIPTION
The real fix here is to not write code that way, but at least people won't get an endlessly changing line 