### PR TITLE
rewrite charlists to use ~c sigil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## main
 
+### Fixes
+
+* fix crash when encountering single-quote charlists (h/t @fhunleth)
+
 ### Improvements
 
+* single-quote charlists are rewritten to use the `~c` sigil (`'foo'` -> `~c'foo'`)
 * when encountering `_ = bar ->`, replace it with `bar ->`
 
 ## v0.7.9

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -44,6 +44,11 @@ defmodule Styler.Style.SingleNode do
     end
   end
 
+  defp style({:__block__, meta, [[int|_] = chars]} = _node) when is_integer(int) do
+    meta = [line: meta[:line]]
+    {:sigil_c, [{:delimiter, ~s(")} | meta], [{:<<>>, meta, [List.to_string(chars)]}, []]}
+  end
+
   defp style({{:., dm, [{:__aliases__, am, [:Enum]}, :into]}, funm, [enum, collectable | rest]} = node) do
     if Style.empty_map?(collectable), do: {{:., dm, [{:__aliases__, am, [:Map]}, :new]}, funm, [enum | rest]}, else: node
   end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -11,6 +11,11 @@
 defmodule Styler.Style.SingleNodeTest do
   use Styler.StyleCase, async: true
 
+  test "rewrites single quote charlists to ~c" do
+    assert_style "'foo'", ~s(~c"foo")
+    assert_style "[1, :two]"
+  end
+
   describe "def / defp" do
     test "0-arity functions have parens removed" do
       assert_style("def foo(), do: :ok", "def foo, do: :ok")

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -11,9 +11,8 @@
 defmodule Styler.Style.SingleNodeTest do
   use Styler.StyleCase, async: true
 
-  test "rewrites single quote charlists to ~c" do
-    assert_style "'foo'", ~s(~c"foo")
-    assert_style "[1, :two]"
+  test "charlist literals: rewrites single quote charlists to ~c" do
+    assert_style("'foo'", ~s|~c'foo'|)
   end
 
   describe "def / defp" do


### PR DESCRIPTION
Ref #45 

I think I might need `if meta[:delimiter] and Enum.all?(chars, &is_integer/1) do` for this to not rewrite things we don't want to, but need more testing and thinking time