### PR TITLE
Use double quotes for ~c sigil

### DIFF
--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -46,10 +46,11 @@ defmodule Styler.Style.SingleNode do
 
   # Our use of the `literal_encoder` option of `Code.string_to_quoted_with_comments!/2` creates
   # invalid charlists literal AST nodes from `'foo'`. this rewrites them to use the `~c` sigil
-  # 'foo' => ~c'foo'
+  # 'foo' => ~c"foo".
   defp style({:__block__, meta, [[int | _] = chars]} = node) when is_integer(int) do
     if meta[:delimiter] == "'" do
-      {:sigil_c, meta, [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
+      new_meta = Keyword.put(meta, :delimiter, "\"")
+      {:sigil_c, new_meta, [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
     else
       node
     end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -12,7 +12,8 @@ defmodule Styler.Style.SingleNodeTest do
   use Styler.StyleCase, async: true
 
   test "charlist literals: rewrites single quote charlists to ~c" do
-    assert_style("'foo'", ~s|~c'foo'|)
+    assert_style("'foo'", ~s|~c"foo"|)
+    assert_style(~s|'"'|, ~s|~c"\\""|)
   end
 
   describe "def / defp" do


### PR DESCRIPTION
Double quotes are more commonly used. This adds a test for embedded double quotes in the original string, but Elixir handles this case already.

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!
