### PR TITLE
fix: add missing infix operators

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -204,7 +204,7 @@ defmodule Styler.Style.Pipes do
   # most of these values were lifted directly from credoa's pipe_chain_start.ex
   @literal ~w(__block__ __aliases__ unquote)a
   @value_constructors ~w(% %{} .. <<>> @ {} ^ & fn from)a
-  @infix_ops ~w(++ -- && || in - * + / > < <= >= == and or not != !==)a
+  @infix_ops ~w(++ -- && || in - * + / > < <= >= == and or != !==)a
   @binary_ops ~w(<> <- ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~)a
   @valid_starts @literal ++ @value_constructors ++ @infix_ops ++ @binary_ops
 

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -204,7 +204,7 @@ defmodule Styler.Style.Pipes do
   # most of these values were lifted directly from credoa's pipe_chain_start.ex
   @literal ~w(__block__ __aliases__ unquote)a
   @value_constructors ~w(% %{} .. <<>> @ {} ^ & fn from)a
-  @infix_ops ~w(++ -- && || in - * + / > < <= >= ==)a
+  @infix_ops ~w(++ -- && || in - * + / > < <= >= == and or not != !==)a
   @binary_ops ~w(<> <- ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~)a
   @valid_starts @literal ++ @value_constructors ++ @infix_ops ++ @binary_ops
 


### PR DESCRIPTION
## Changelog

- Added missing infix operators.

## Summary

I am uncertain if this is the correct solution, but when I ran `mix format`, I encountered errors related to the usage of `and`, `or`, `!=`, and `!==` operators.

Sample Code Snippet: 
```
((id == "" or id == requested_id) and (type == "" or type == requested_type))
|> foo()
```

After `mix format`:
```
(id == "" or id == requested_id)
|> and(type == "" or type == requested_type)
|> foo()
```

As you can observe, this syntax is not valid. Therefore, I added these operators in `infix_ops` list.

## Checks

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!
