### PR TITLE
with statement rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added right-hand-pattern-matching rewrites to `for` and `with` left arrow expressions `<-`
   (ex: `with map = %{} <- foo()` => `with %{} = map <- foo`)
+* `with` statement rewrites, solving the following credo rules
+  * `Credo.Check.Readability.WithSingleClause`
+  * `Credo.Check.Refactor.RedundantWithClauseResult`
+  * `Credo.Check.Refactor.WithClauses`
 
 ## v0.8.5
 

--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ If you're using Credo and Styler, **we recommend disabling these rules in `.cred
 | `Credo.Check.Readability.SinglePipe` | |
 | `Credo.Check.Readability.StrictModuleLayout` | **potentially breaks compilation** (see notes above) |
 | `Credo.Check.Readability.UnnecessaryAliasExpansion` | |
+| `Credo.Check.Readability.WithSingleClause` | |
 | `Credo.Check.Refactor.CaseTrivialMatches` | |
 | `Credo.Check.Refactor.FilterCount` | in pipes only |
 | `Credo.Check.Refactor.MapInto` | in pipes only |
 | `Credo.Check.Refactor.MapJoin` | in pipes only |
 | `Credo.Check.Refactor.PipeChainStart` | allows ecto's `from`|
+| `Credo.Check.Refactor.WithClauses` | |
 
 ## Your first Styling
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you're using Credo and Styler, **we recommend disabling these rules in `.cred
 | `Credo.Check.Refactor.MapInto` | in pipes only |
 | `Credo.Check.Refactor.MapJoin` | in pipes only |
 | `Credo.Check.Refactor.PipeChainStart` | allows ecto's `from`|
+| `Credo.Check.Refactor.RedundantWithClauseResult` | |
 | `Credo.Check.Refactor.WithClauses` | |
 
 ## Your first Styling

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -145,6 +145,17 @@ defmodule Styler.Style.SingleNode do
 
   defp style({:fn, m, arrows}), do: {:fn, m, r_align_matches(arrows)}
 
+  defp style(
+         {:with, m,
+          [
+            {:<-, am, [success, head]},
+            [{{:__block__, do_meta, [:do]}, do_body}, {{:__block__, _else_meta, [:else]}, elses}]
+          ]}
+       ) do
+    clauses = [{{:__block__, am, [:do]}, [{:->, do_meta, [[success], do_body]} | elses]}]
+    style({:case, m, [head, clauses]})
+  end
+
   defp style(node), do: node
 
   defp r_align_matches(arrows) when is_list(arrows),

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -163,6 +163,9 @@ defmodule Styler.Style.SingleNode do
       good_start = Enum.reverse(reversed_start)
       body_statements = Enum.reverse(body_statements)
 
+      # @TODO check for redundant final node
+      # - can only be redundant if the body itself is a single ast node (after body has body_statements added)
+
       if Enum.any?(pre_with_statements) or Enum.any?(body_statements) do
         with_statement = {:with, m, good_start ++ [[{do_, {:__block__, [], body_statements ++ List.wrap(body)}} | elses]]}
         {:__block__, m, pre_with_statements ++ [with_statement]}

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -195,7 +195,7 @@ defmodule Styler.Style.SingleNode do
           with
       end
     else
-      # maybe this isn't a with statement - could be a functino named `with`
+      # maybe this isn't a with statement - could be a function named `with`
       # or it's just a with statement with no arrows, but that's too saddening to imagine
       with
     end

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -60,15 +60,14 @@ defmodule Styler do
 
     {ast, comments} =
       input
-      |> Styler.string_to_quoted_with_comments(to_string(file))
+      |> string_to_quoted_with_comments(to_string(file))
       |> style(file, opts)
 
     quoted_to_string(ast, comments, formatter_opts)
   end
 
-  @doc """
-  Wraps `Code.string_to_quoted_with_comments` with our desired options
-  """
+  @doc false
+  # Wrap `Code.string_to_quoted_with_comments` with our desired options
   def string_to_quoted_with_comments(code, file \\ "nofile") when is_binary(code) do
     Code.string_to_quoted_with_comments!(code,
       literal_encoder: &__MODULE__.literal_encoder/2,
@@ -81,9 +80,8 @@ defmodule Styler do
   @doc false
   def literal_encoder(a, b), do: {:ok, {:__block__, b, [a]}}
 
-  @doc """
-  Turns an ast and comments back into code, formatting it along the way.
-  """
+  @doc false
+  # Turns an ast and comments back into code, formatting it along the way.
   def quoted_to_string(ast, comments, formatter_opts \\ []) do
     opts = [{:comments, comments}, {:escape, false} | formatter_opts]
     {line_length, opts} = Keyword.pop(opts, :line_length, 122)

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -210,21 +210,24 @@ defmodule Styler.Style.SingleNodeTest do
     end
 
     test "with statements" do
-      assert_style """
-      with ok = :ok <- foo, yeehaw() do
-        ok
-      else
-        error = :error -> error
-        other -> other
-      end
-      ""","""
-      with :ok = ok <- foo, yeehaw() do
-        ok
-      else
-        :error = error -> error
-        other -> other
-      end
-      """
+      assert_style(
+        """
+        with ok = :ok <- foo, yeehaw() do
+          ok
+        else
+          error = :error -> error
+          other -> other
+        end
+        """,
+        """
+        with :ok = ok <- foo, yeehaw() do
+          ok
+        else
+          :error = error -> error
+          other -> other
+        end
+        """
+      )
     end
   end
 
@@ -390,16 +393,14 @@ defmodule Styler.Style.SingleNodeTest do
     end
 
     test "doesn't rewrite nontrivial withs" do
-      assert_style(
-        """
-        with :ok <- foo, :ok <- bar do
-          :success
-        else
-          :error -> 1
-          :fail -> 2
-        end
-        """
-      )
+      assert_style("""
+      with :ok <- foo, :ok <- bar do
+        :success
+      else
+        :error -> 1
+        :fail -> 2
+      end
+      """)
     end
   end
 end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -444,5 +444,30 @@ defmodule Styler.Style.SingleNodeTest do
         """
       )
     end
+
+    @tag :skip
+    # not implemented
+    test "Credo.Check.Refactor.RedundantWithClauseResult" do
+      assert_style """
+      with {:ok, a} <- foo(),
+           {:ok, b} <- bar(a) do
+        {:ok, b}
+      end
+      """,
+      """
+      with {:ok, a} <- foo() do
+        bar(a)
+      end
+      """
+
+      assert_style """
+      with {:ok, a} <- foo(),
+           {:ok, b} <- bar(a) do
+        {:ok, b}
+      else
+        error -> handle(error)
+      end
+      """
+    end
   end
 end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -372,6 +372,12 @@ defmodule Styler.Style.SingleNodeTest do
   end
 
   describe "with statements" do
+    test "doesn't false positive with vars" do
+      assert_style("""
+      if naming_is_hard, do: with
+      """)
+    end
+
     test "Credo.Check.Readability.WithSingleClause" do
       assert_style(
         """
@@ -448,26 +454,28 @@ defmodule Styler.Style.SingleNodeTest do
     @tag :skip
     # not implemented
     test "Credo.Check.Refactor.RedundantWithClauseResult" do
-      assert_style """
-      with {:ok, a} <- foo(),
-           {:ok, b} <- bar(a) do
-        {:ok, b}
-      end
-      """,
-      """
-      with {:ok, a} <- foo() do
-        bar(a)
-      end
-      """
+      assert_style(
+        """
+        with {:ok, a} <- foo(),
+             {:ok, b} <- bar(a) do
+          {:ok, b}
+        end
+        """,
+        """
+        with {:ok, a} <- foo() do
+          bar(a)
+        end
+        """
+      )
 
-      assert_style """
+      assert_style("""
       with {:ok, a} <- foo(),
            {:ok, b} <- bar(a) do
         {:ok, b}
       else
         error -> handle(error)
       end
-      """
+      """)
     end
   end
 end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -210,7 +210,21 @@ defmodule Styler.Style.SingleNodeTest do
     end
 
     test "with statements" do
-      
+      assert_style """
+      with ok = :ok <- foo, yeehaw() do
+        ok
+      else
+        error = :error -> error
+        other -> other
+      end
+      ""","""
+      with :ok = ok <- foo, yeehaw() do
+        ok
+      else
+        :error = error -> error
+        other -> other
+      end
+      """
     end
   end
 

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -208,6 +208,10 @@ defmodule Styler.Style.SingleNodeTest do
       end
       """)
     end
+
+    test "with statements" do
+      
+    end
   end
 
   describe "numbers" do
@@ -344,6 +348,41 @@ defmodule Styler.Style.SingleNodeTest do
         else
           Logger.warning("it's false")
           nil
+        end
+        """
+      )
+    end
+  end
+
+  describe "with statements" do
+    test "rewrites simple withs to cases & styles the case" do
+      assert_style(
+        """
+        with :ok <- foo do
+          :success
+        else
+          error = :error -> error
+          :fail -> :failure
+        end
+        """,
+        """
+        case foo do
+          :ok -> :success
+          :error = error -> error
+          :fail -> :failure
+        end
+        """
+      )
+    end
+
+    test "doesn't rewrite nontrivial withs" do
+      assert_style(
+        """
+        with :ok <- foo, :ok <- bar do
+          :success
+        else
+          :error -> 1
+          :fail -> 2
         end
         """
       )

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -456,8 +456,6 @@ defmodule Styler.Style.SingleNodeTest do
       )
     end
 
-    @tag :skip
-    # not implemented
     test "Credo.Check.Refactor.RedundantWithClauseResult" do
       assert_style(
         """


### PR DESCRIPTION
rewrite two credo rules:

- Credo.Check.Readability.WithSingleClause
- Credo.Check.Refactor.WithClauses

### Testing

There's a lot of weird ways `with` statements can be written.
Need to run this on a big codebase and see what goes kaboom... (I don't have any `with ..., do:` tests, for one)

**update**: Ran against a large codebase without errors: :shipit: 