### PR TITLE
fix: macros with only 1 block argument

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -225,6 +225,8 @@ defmodule Styler.Style.Pipes do
   defp valid_pipe_start?({{:., _, _}, _, _}), do: false
   # variable
   defp valid_pipe_start?({variable, _, nil}) when is_atom(variable), do: true
+  # macro with single block argument
+  defp valid_pipe_start?({fun, _, [[{{:__block__, _, [:do]}, {:__block__, [], []}}]]}) when is_atom(fun), do: true
   # 0-arity function_call()
   defp valid_pipe_start?({fun, _, []}) when is_atom(fun), do: true
   # function_call(with, args) or sigils. sigils are allowed, function w/ args is not

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -226,7 +226,7 @@ defmodule Styler.Style.Pipes do
   # variable
   defp valid_pipe_start?({variable, _, nil}) when is_atom(variable), do: true
   # macro with single block argument
-  defp valid_pipe_start?({fun, _, [[{{:__block__, _, [:do]}, {:__block__, [], []}}]]}) when is_atom(fun), do: true
+  defp valid_pipe_start?({fun, _, [[{{:__block__, _, [:do]}, _}]]}) when is_atom(fun) and fun not in @blocks, do: true
   # 0-arity function_call()
   defp valid_pipe_start?({fun, _, []}) when is_atom(fun), do: true
   # function_call(with, args) or sigils. sigils are allowed, function w/ args is not

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -12,6 +12,24 @@ defmodule Styler.Style.PipesTest do
   use Styler.StyleCase, async: true
 
   describe "big picture" do
+    test "macros with single do block argument" do
+      assert_style("""
+      IO.puts(
+        foo do
+        end
+      )
+      """)
+    end
+
+    test "macro with arg and do block" do
+      assert_style("""
+      "baz"
+      |> foo do
+      end
+      |> IO.puts()
+      """)
+    end
+
     test "doesn't modify valid pipe" do
       assert_style("""
       a()

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -16,15 +16,33 @@ defmodule Styler.Style.PipesTest do
       assert_style("""
       IO.puts(
         foo do
+          "foo"
         end
       )
       """)
+
+      assert_style(
+        """
+        foo do
+          "foo"
+        end
+        |> IO.puts()
+        """,
+        """
+        IO.puts(
+          foo do
+            "foo"
+          end
+        )
+        """
+      )
     end
 
     test "macro with arg and do block" do
       assert_style("""
       "baz"
       |> foo do
+        "foo"
       end
       |> IO.puts()
       """)


### PR DESCRIPTION
This patch fixes a crash where macros with a single do block argument
that were being piped into a function.

Now, the following code transformation will occur instead of a crash:

```elixir
# from
foo do
  "hi"
end
|> IO.puts()

# to
IO.puts(
  foo do
    "hi"
  end
)
```

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!
