### PR TITLE
empty charlists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Ex${{matrix.elixir}}/OTP${{matrix.otp}}
     strategy:
       matrix:
-        elixir: ['1.14.2', '1.15.0']
+        elixir: ['1.14.2', '1.15.7']
         otp: ['25.1.2']
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## main
 
+### Improvements
+
+* charlists: leave charlist rewriting to elixir's formatter on elixir >= 1.15
+
+### Fixes
+
+* charlists: rewrite empty charlist to use sigil (`''` => `~c""`)
+
 ## v0.10.2
 
 ### Improvements

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -35,10 +35,9 @@ defmodule Styler.Style.SingleNode do
   # Our use of the `literal_encoder` option of `Code.string_to_quoted_with_comments!/2` creates
   # invalid charlists literal AST nodes from `'foo'`. this rewrites them to use the `~c` sigil
   # 'foo' => ~c"foo".
-  defp style({:__block__, meta, [[int | _] = chars]} = node) when is_integer(int) do
+  defp style({:__block__, meta, [chars]} = node) when is_list(chars) do
     if meta[:delimiter] == "'" do
-      new_meta = Keyword.put(meta, :delimiter, "\"")
-      {:sigil_c, new_meta, [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
+      {:sigil_c, Keyword.put(meta, :delimiter, "\""), [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
     else
       node
     end

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -32,14 +32,18 @@ defmodule Styler.Style.SingleNode do
 
   def run({node, meta}, ctx), do: {:cont, {style(node), meta}, ctx}
 
-  # Our use of the `literal_encoder` option of `Code.string_to_quoted_with_comments!/2` creates
-  # invalid charlists literal AST nodes from `'foo'`. this rewrites them to use the `~c` sigil
-  # 'foo' => ~c"foo".
-  defp style({:__block__, meta, [chars]} = node) when is_list(chars) do
-    if meta[:delimiter] == "'" do
-      {:sigil_c, Keyword.put(meta, :delimiter, "\""), [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
-    else
-      node
+  # old `'charlist'` literals to `~c"charlist"`
+  # as of 1.15, elixir's formatter takes care of this for us.
+  if Version.match?(System.version(), "< 1.15.0-dev") do
+    # Our use of the `literal_encoder` option of `Code.string_to_quoted_with_comments!/2` creates
+    # invalid charlists literal AST nodes from `'foo'`. this rewrites them to use the `~c` sigil
+    # 'foo' => ~c"foo".
+    defp style({:__block__, meta, [chars]} = node) when is_list(chars) do
+      if meta[:delimiter] == "'" do
+        {:sigil_c, Keyword.put(meta, :delimiter, "\""), [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
+      else
+        node
+      end
     end
   end
 

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -32,18 +32,13 @@ defmodule Styler.Style.SingleNode do
 
   def run({node, meta}, ctx), do: {:cont, {style(node), meta}, ctx}
 
-  # old `'charlist'` literals to `~c"charlist"`
   # as of 1.15, elixir's formatter takes care of this for us.
   if Version.match?(System.version(), "< 1.15.0-dev") do
-    # Our use of the `literal_encoder` option of `Code.string_to_quoted_with_comments!/2` creates
-    # invalid charlists literal AST nodes from `'foo'`. this rewrites them to use the `~c` sigil
-    # 'foo' => ~c"foo".
+    # 'charlist' => ~c"charlist"
     defp style({:__block__, meta, [chars]} = node) when is_list(chars) do
-      if meta[:delimiter] == "'" do
-        {:sigil_c, Keyword.put(meta, :delimiter, "\""), [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]}
-      else
-        node
-      end
+      if meta[:delimiter] == "'",
+        do: {:sigil_c, Keyword.put(meta, :delimiter, "\""), [{:<<>>, [line: meta[:line]], [List.to_string(chars)]}, []]},
+        else: node
     end
   end
 

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -11,11 +11,12 @@
 defmodule Styler.Style.SingleNodeTest do
   use Styler.StyleCase, async: true
 
-  test "charlist literals: rewrites single quote charlists to ~c" do
-    assert_style("'foo'", ~s|~c"foo"|)
-    assert_style(~s|'"'|, ~s|~c"\\""|)
-    # elixir's formatter >= 1.15 does this for us.
-    assert_style("''", ~s|~c""|)
+  if Version.match?(System.version(), "< 1.15.0-dev") do
+    test "charlist literals: rewrites single quote charlists to ~c" do
+      assert_style("'foo'", ~s|~c"foo"|)
+      assert_style(~s|'"'|, ~s|~c"\\""|)
+      assert_style("''", ~s|~c""|)
+    end
   end
 
   test "Logger.warn to Logger.warning" do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -14,6 +14,7 @@ defmodule Styler.Style.SingleNodeTest do
   test "charlist literals: rewrites single quote charlists to ~c" do
     assert_style("'foo'", ~s|~c"foo"|)
     assert_style(~s|'"'|, ~s|~c"\\""|)
+    # elixir's formatter >= 1.15 does this for us.
     assert_style("''", ~s|~c""|)
   end
 

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -14,6 +14,7 @@ defmodule Styler.Style.SingleNodeTest do
   test "charlist literals: rewrites single quote charlists to ~c" do
     assert_style("'foo'", ~s|~c"foo"|)
     assert_style(~s|'"'|, ~s|~c"\\""|)
+    assert_style("''", ~s|~c""|)
   end
 
   test "Logger.warn to Logger.warning" do


### PR DESCRIPTION
noticed `''` being rewritten to `~c""` after updating elixir to 1.15. wondered what bug existed in styler that it required being on 1.15 to make that rewrite... and then realized elixir itself is now doing this!