### PR TITLE
Add a newline after moduledocs

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -71,7 +71,8 @@ defmodule Styler.Style.ModuleDirectives do
   @directives ~w(alias import require use)a
   @attr_directives ~w(moduledoc shortdoc behaviour)a
 
-  @moduledoc_false {:@, [line: nil], [{:moduledoc, [line: nil], [{:__block__, [line: nil], [false]}]}]}
+  @moduledoc_false {:@, [end_of_expression: [newlines: 2, line: nil], line: nil],
+                    [{:moduledoc, [line: nil], [{:__block__, [line: nil], [false]}]}]}
 
   def run({{:defmodule, _, children}, _} = zipper, ctx) do
     [name, [{{:__block__, do_meta, [:do]}, _body}]] = children
@@ -149,7 +150,7 @@ defmodule Styler.Style.ModuleDirectives do
       end)
 
     shortdocs = directives[:"@shortdoc"] || []
-    moduledocs = directives[:"@moduledoc"] || List.wrap(moduledoc)
+    moduledocs = (directives[:"@moduledoc"] || List.wrap(moduledoc)) |> reset_newlines()
     behaviours = expand_and_sort(directives[:"@behaviour"] || [])
 
     uses = (directives[:use] || []) |> Enum.flat_map(&expand_directive/1) |> reset_newlines()

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -82,6 +82,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
         defmodule B do
           @moduledoc false
+
           defmodule C do
             @moduledoc false
           end
@@ -89,6 +90,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
         defmodule Bar do
           @moduledoc false
+
           alias Bop.Bop
 
           :ok
@@ -100,11 +102,13 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
         defmodule Foo do
           @moduledoc false
+
           use Bar
         end
 
         defmodule Foo do
           @moduledoc false
+
           alias Foo.Bar
           alias Foo.Baz
         end
@@ -175,6 +179,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
                      |> File.read!()
                      |> String.split("<!-- MDOC !-->")
                      |> Enum.fetch!(1)
+
           @behaviour Chaotic
           @behaviour Lawful
 
@@ -397,6 +402,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule Foo do
           # mdf
           @moduledoc false
+
           alias A.A
           # B
           alias B.B


### PR DESCRIPTION
Closes #104

stalled out due to naive approach not passing property tests, hinting that a big overhaul might be required to make this happen 😭 