### PR TITLE
spike module directive move_preceding_comments

### DIFF
--- a/lib/style.ex
+++ b/lib/style.ex
@@ -98,6 +98,11 @@ defmodule Styler.Style do
     |> Zipper.down()
   end
 
+  def move_preceding_comments(comments, _, _) do
+    IO.puts "impl plz!"
+    comments
+  end
+
   @doc """
   Set the line of all comments with `line` in `range_start..range_end` to instead have line `range_start`
   """

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -85,7 +85,8 @@ defmodule Styler.Style.ModuleDirectives do
 
       case Zipper.node(body_zipper) do
         {:__block__, _, _} ->
-          {:skip, organize_directives(body_zipper, moduledoc), ctx}
+          {zipper, comments} = organize_directives(body_zipper, moduledoc, ctx.comments)
+          {:skip, zipper, %{ctx | comments: comments}
 
         {:@, _, [{:moduledoc, _, _}]} ->
           # a module whose only child is a moduledoc. nothing to do here!
@@ -116,7 +117,8 @@ defmodule Styler.Style.ModuleDirectives do
 
   def run({{directive, _, children}, _} = zipper, ctx) when directive in @directives and is_list(children) do
     parent = zipper |> Style.ensure_block_parent() |> Zipper.up()
-    {:skip, organize_directives(parent), ctx}
+    {zipper, comments} = organize_directives(parent, ctx.comments)
+    {:skip, zipper, %{ctx | comments: comments}
   end
 
   def run(zipper, ctx), do: {:cont, zipper, ctx}
@@ -132,7 +134,7 @@ defmodule Styler.Style.ModuleDirectives do
   # a dynamic module name, like `defmodule my_variable do ... end`
   defp moduledoc(_), do: nil
 
-  defp organize_directives(parent, moduledoc \\ nil) do
+  defp organize_directives(parent, moduledoc \\ nil, comments) do
     {directives, nondirectives} =
       parent
       |> Zipper.children()
@@ -214,32 +216,30 @@ defmodule Styler.Style.ModuleDirectives do
   # This fixes that error by ensuring the following property:
   # A given node of AST cannot have a line number greater than the next AST node.
   # Et voila! Comments behave much better.
-  defp fix_line_numbers(directives, acc \\ [], first_non_directive)
+  defp fix_line_numbers(directives, acc \\ [], first_non_directive, comments)
 
-  defp fix_line_numbers([this, next | rest], acc, first_non_directive) do
-    this = cap_line(this, next)
-    fix_line_numbers([next | rest], [this | acc], first_non_directive)
+  defp fix_line_numbers([this, next | rest], acc, first_non_directive, comments) do
+    {this, comments} = cap_line(this, next)
+    fix_line_numbers([next | rest], [this | acc], first_non_directive, comments)
   end
 
-  defp fix_line_numbers([last], acc, first_non_directive) do
-    last = if first_non_directive, do: cap_line(last, first_non_directive), else: last
-    Enum.reverse([last | acc])
+  defp fix_line_numbers([last], acc, first_non_directive, comments) do
+    {last, comments} = if first_non_directive, do: cap_line(last, first_non_directive), else: {last, comments}
+    {Enum.reverse([last | acc]), comments}
   end
 
-  defp fix_line_numbers([], [], _), do: []
+  defp fix_line_numbers([], [], _, comments), do: {[], comments}
 
-  defp cap_line({_, this_meta, _} = this, {_, next_meta, _}) do
+  defp cap_line({_, this_meta, _} = this, {_, next_meta, _}, comments) do
     this_line = this_meta[:line]
     next_line = next_meta[:line]
 
     if this_line > next_line do
-      # Subtracting 2 helps the behaviour with one-liner comments preceding the next node. It's a bit of a hack.
-      # TODO: look into the comments list and
-      # 1. move comment blocks preceding `this` up with it
-      # 2. find the earliest comment before `next` and set `new_line` to that value - 1
-      Style.set_line(this, next_line - 2, delete_newlines: false)
+      comments = Style.move_preceding_comments(comments, this_line, next_line - 2)
+      this = Style.set_line(this, next_line - 2, delete_newlines: false)
+      {this, comments}
     else
-      this
+      {this, comments}
     end
   end
 

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -235,6 +235,16 @@ defmodule Styler.Style.ModuleDirectives do
     next_line = next_meta[:line]
 
     if this_line > next_line do
+      # it's not enought to say "give me comments from previous lines"
+      # because the precious line could be
+      # alias A # this is A
+      # and so we'd steal the alias from A!
+      # instead, we need to annotate each node with the line number of the preceding line of ast
+      # not sure what the best way to do tha tis. it needs to be Zipper.prev, not left, unless I use max_line to get the max from each prev...
+      # once things are annotated, we can know exactly what range to look for comments to attach to this node
+      # (preceding_ast_line + 1).. this_line
+      # the comments need to be popped out of place and put back into comments list as a group,
+      # to make sure i don't intersperse comments
       comments = Style.move_preceding_comments(comments, this_line, next_line - 2)
       this = Style.set_line(this, next_line - 2, delete_newlines: false)
       {this, comments}

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -397,9 +397,11 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule Foo do
           # mdf
           @moduledoc false
+          # A
           alias A.A
           # B
           alias B.B
+          # C
           alias C.C
 
           # foo
@@ -407,9 +409,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
             # ok
             :ok
           end
-
-          # C
-          # A
         end
         """
       )


### PR DESCRIPTION
this is the final known comment-misplacement in styler