### PR TITLE
Allow custom price-style delimiter on large numbers

### DIFF
--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -45,6 +45,10 @@ defmodule Styler.Style.SingleNode do
   # Add / Correct `_` location in large numbers. Formatter handles large number (>5 digits) rewrites,
   # but doesn't rewrite typos like `100_000_0`, so it's worthwhile to have Styler do this
   #
+  # Styler does allow tokens to end with a `_` followed by two digit characters. In this case
+  # no rewrite will happen. While conflicting with Credo, this exception allows numbers to be written
+  # as `149_00` to represent a price in cents for ease of readability.
+  #
   # `?-` isn't part of the number node - it's its parent - so all numbers are positive at this point
   defp style({:__block__, meta, [number]}) when is_number(number) and number >= 10_000 do
     # Checking here rather than in the anon function due to compiler bug https://github.com/elixir-lang/elixir/issues/10485
@@ -62,7 +66,9 @@ defmodule Styler.Style.SingleNode do
           token
 
         token when integer? ->
-          delimit(token)
+          if Regex.match?(~r/^.+\_\d{2}$/, token),
+            do: token,
+            else: delimit(token)
 
         # is float
         token ->

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -271,6 +271,7 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("-543213", "-543_213")
       assert_style("123456789", "123_456_789")
       assert_style("55333.22", "55_333.22")
+      assert_style("149_1491", "1_491_491")
       assert_style("-123456728.0001", "-123_456_728.0001")
     end
 
@@ -282,6 +283,8 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("0x123456")
       assert_style("0b1111_1111_1111_1111")
       assert_style("0o777_7777")
+      assert_style("149_45")
+      assert_style("1_149_00")
     end
   end
 


### PR DESCRIPTION
Instead of skipping the rewrite any time a delimiter already exists, this skips the rewrite only when the token ends with `_00`. While certainly being more costly than something like `String.contains/2` doing `Regex.match?/2` is flexible and might still be acceptable.

Resolves #109

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!
