### PR TITLE
keep module callback ordering relative to `use` directives.

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -69,7 +69,8 @@ defmodule Styler.Style.ModuleDirectives do
   alias Styler.Zipper
 
   @directives ~w(alias import require use)a
-  @attr_directives ~w(moduledoc shortdoc behaviour)a
+  @callback_directives ~w(before_compile after_compile after_verify)a
+  @attr_directives ~w(moduledoc shortdoc behaviour)a ++ @callback_directives
 
   @moduledoc_false {:@, [line: nil], [{:moduledoc, [line: nil], [{:__block__, [line: nil], [false]}]}]}
 
@@ -142,6 +143,9 @@ defmodule Styler.Style.ModuleDirectives do
 
     directives =
       Enum.group_by(directives, fn
+        # callbacks are essentially the same as `use` -- they invoke macros.
+        # so, we need to group / order them with `use` statements to make sure we don't break things!
+        {:@, _, [{callback, _, _}]} when callback in @callback_directives -> :use
         {:@, _, [{attr_name, _, _}]} -> :"@#{attr_name}"
         {directive, _, _} -> directive
       end)

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -69,8 +69,8 @@ defmodule Styler.Style.ModuleDirectives do
   alias Styler.Zipper
 
   @directives ~w(alias import require use)a
-  @callback_directives ~w(before_compile after_compile after_verify)a
-  @attr_directives ~w(moduledoc shortdoc behaviour)a ++ @callback_directives
+  @callback_attrs ~w(before_compile after_compile after_verify)a
+  @attr_directives ~w(moduledoc shortdoc behaviour)a ++ @callback_attrs
 
   @moduledoc_false {:@, [line: nil], [{:moduledoc, [line: nil], [{:__block__, [line: nil], [false]}]}]}
 
@@ -145,7 +145,7 @@ defmodule Styler.Style.ModuleDirectives do
       Enum.group_by(directives, fn
         # callbacks are essentially the same as `use` -- they invoke macros.
         # so, we need to group / order them with `use` statements to make sure we don't break things!
-        {:@, _, [{callback, _, _}]} when callback in @callback_directives -> :use
+        {:@, _, [{callback, _, _}]} when callback in @callback_attrs -> :use
         {:@, _, [{attr_name, _, _}]} -> :"@#{attr_name}"
         {directive, _, _} -> directive
       end)

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -343,6 +343,17 @@ defmodule Styler.Style.ModuleDirectivesTest do
       )
     end
 
+    test "groups module callbacks with uses, keeping ordering" do
+      assert_style """
+      defmacro __using__(_) do
+        quote do
+          @after_compile Foo
+          use Bar
+        end
+      end
+      """
+    end
+
     test "interwoven directives w/o the context of a module" do
       assert_style(
         """


### PR DESCRIPTION
closes #120