### PR TITLE
Rewrite then/2 when function is a named function reference

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -144,10 +144,6 @@ defmodule Styler.Style.Pipes do
   defp fix_pipe({:|>, m, [lhs, {fun, m2, nil}]}), do: {:|>, m, [lhs, {fun, m2, []}]}
   # a |> then(&fun/1) |> c => a |> fun() |> c()
   defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [{fun, m2, _}, _]}]}]}]}), do: {:|>, m, [lhs, {fun, m2, []}]}
-  # a |> then(&fun(&1, d)) |> c => a |> fun(d) |> c()
-  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{fun, m2, [{:&, _, _} | args]}]}]}]}),
-    do: {:|>, m, [lhs, {fun, m2, args}]}
-
   # Credo.Check.Readability.PipeIntoAnonymousFunctions
   # rewrite anonymous function invocation to use `then/2`
   # `a |> (& &1).() |> c()` => `a |> then(& &1) |> c()`

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -144,6 +144,10 @@ defmodule Styler.Style.Pipes do
   defp fix_pipe({:|>, m, [lhs, {fun, m2, nil}]}), do: {:|>, m, [lhs, {fun, m2, []}]}
   # a |> then(&fun/1) |> c => a |> fun() |> c()
   defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [{fun, m2, _}, _]}]}]}]}), do: {:|>, m, [lhs, {fun, m2, []}]}
+  # a |> then(&fun(&1, d)) |> c => a |> fun(d) |> c()
+  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{fun, m2, [{:&, _, _} | args]}]}]}]}),
+    do: {:|>, m, [lhs, {fun, m2, args}]}
+
   # Credo.Check.Readability.PipeIntoAnonymousFunctions
   # rewrite anonymous function invocation to use `then/2`
   # `a |> (& &1).() |> c()` => `a |> then(& &1) |> c()`

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -142,6 +142,8 @@ defmodule Styler.Style.Pipes do
 
   # a |> fun => a |> fun()
   defp fix_pipe({:|>, m, [lhs, {fun, m2, nil}]}), do: {:|>, m, [lhs, {fun, m2, []}]}
+  # a |> then(&fun/1) |> c => a |> fun() |> c()
+  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [{fun, m2, _}, _]}]}]}]}), do: {:|>, m, [lhs, {fun, m2, []}]}
   # Credo.Check.Readability.PipeIntoAnonymousFunctions
   # rewrite anonymous function invocation to use `then/2`
   # `a |> (& &1).() |> c()` => `a |> then(& &1) |> c()`

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -502,9 +502,7 @@ defmodule Styler.Style.PipesTest do
       assert_style("a |> then(&fun/1) |> c", "a |> fun() |> c()")
       assert_style("a |> then(&DateTime.from_is8601/1) |> c", "a |> DateTime.from_is8601() |> c()")
       assert_style("a |> then(&DateTime.from_is8601/1)", "DateTime.from_is8601(a)")
-      assert_style("a |> then(&fun(&1)) |> c", "a |> fun() |> c()")
-      assert_style("a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()")
-      assert_style("a |> then(&fun(d, &1)) |> c", "a |> then(&fun(d, &1)) |> c()")
+      assert_style("a |> then(&fun(&1, d)) |> c", "a |> then(&fun(&1, d)) |> c()")
     end
 
     test "adds parens to 1-arity pipes" do

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -498,6 +498,13 @@ defmodule Styler.Style.PipesTest do
       assert_style("a |> (fn x -> x end).() |> c", "a |> then(fn x -> x end) |> c()")
     end
 
+    test "rewrites then/2 when the passed function is a named function reference" do
+      assert_style("a |> then(&fun/1) |> c", "a |> fun() |> c()")
+      assert_style("a |> then(&DateTime.from_is8601/1) |> c", "a |> DateTime.from_is8601() |> c()")
+      assert_style("a |> then(&DateTime.from_is8601/1)", "DateTime.from_is8601(a)")
+      assert_style("a |> then(&fun(&1, d)) |> c", "a |> then(&fun(&1, d)) |> c()")
+    end
+
     test "adds parens to 1-arity pipes" do
       assert_style("a |> b |> c", "a |> b() |> c()")
     end

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -502,7 +502,9 @@ defmodule Styler.Style.PipesTest do
       assert_style("a |> then(&fun/1) |> c", "a |> fun() |> c()")
       assert_style("a |> then(&DateTime.from_is8601/1) |> c", "a |> DateTime.from_is8601() |> c()")
       assert_style("a |> then(&DateTime.from_is8601/1)", "DateTime.from_is8601(a)")
-      assert_style("a |> then(&fun(&1, d)) |> c", "a |> then(&fun(&1, d)) |> c()")
+      assert_style("a |> then(&fun(&1)) |> c", "a |> fun() |> c()")
+      assert_style("a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()")
+      assert_style("a |> then(&fun(d, &1)) |> c", "a |> then(&fun(d, &1)) |> c()")
     end
 
     test "adds parens to 1-arity pipes" do


### PR DESCRIPTION
- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!

:wave: first and foremost, thanks for creating and maintaining styler! We use it in a large codebase where i stumbled over some occurrences of named function references passed into `Kernel.then/2`. I couldn't figure when that would be useful so I am opening this PR proposing to have it handled by styler. I've tested this change in our codebase but am happy to get any pointers on what i could've missed!

Let me know if you'd consider adding this to styler (or not! :)