### PR TITLE
Make it configurable (:grimacing:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,32 @@ And that's it! Now when you run `mix format` you'll also get the benefits of Sty
 
 ### Configuration
 
-There isn't any! This is intentional.
+There isn't much! This is intentional.
 
 Styler is @adobe's internal Style Guide Enforcer - allowing exceptions to the styles goes against that ethos. Happily, it's open source and thus yours to do with as you will =)
+
+However, it's possible to gradually implement Styler via minimal config in `.formatter.exs` file:
+
+```
+[
+  plugins: [Styler],
+  styler: [
+    # List of rules to enable
+
+    # Can have a keyword list of options
+    {Styler.Style.ModuleDirectives, []},
+
+    # Or just a module name
+    Styler.Style.Pipes
+  ]
+]
+```
+
+By default, if the `styler` key is not present, all rules are enabled.
+
+#### Supported options
+
+* `ignore_prefixes` - a list of file prefixes to skip when applying the rule. Example: `ignore_prefixes: ["test/"]`
 
 ## Features (or as we call them, "Styles")
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -672,4 +672,34 @@ defmodule Styler.Style.PipesTest do
       end
     end
   end
+
+  describe "configurable" do
+    test "filename prefix is ignored" do
+      assert_style("f(g(h(x))) |> j()", "f(g(h(x))) |> j()", "lib/test.exs",
+        config: [
+          {Styler.Style.Pipes, ignore_prefixes: ["lib/"]}
+        ]
+      )
+    end
+
+    test "filename not in prefix is styled" do
+      assert_style("f(g(h(x))) |> j()", "x |> h() |> g() |> f() |> j()", "test/test.exs",
+        config: [
+          {Styler.Style.Pipes, ignore_prefixes: ["lib/"]}
+        ]
+      )
+    end
+
+    test "filename prefix is ignored with multiple prefixes" do
+      assert_style("f(g(h(x))) |> j()", "f(g(h(x))) |> j()", "lib/test.exs",
+        config: [
+          {Styler.Style.Pipes, ignore_prefixes: ["lib/", "test/"]}
+        ]
+      )
+    end
+
+    test "if style is not present, no changes are made" do
+      assert_style("f(g(h(x))) |> j()", "f(g(h(x))) |> j()", "lib/test.exs", config: [])
+    end
+  end
 end


### PR DESCRIPTION
Hello!

In order to ease installation in a larger project, it might make it easier to be able to only enable some chuncks of the styler at a time, and/or only for some files.

This addresses that.

I know this essentially breaks core values of elixir-styler! No worries if this never get merged, at least it could be a starting point for others.

Tests could be better as well, they're kinda "there" as I didn't find a better place / didn't want to create a file. Don't hestitate to take over / cherrypick what's good if you feel like merging this!

Cheers