### PR TITLE
fix: fix unary operators in pipes (fixes adobe#128)

### DIFF
--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -505,6 +505,10 @@ defmodule Styler.Style.PipesTest do
       assert_style "a |> then(&fun(&1)) |> c", "a |> fun() |> c()"
       assert_style "a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()"
 
+      # Unary operators
+      assert_style "a |> then(&(-&1)) |> c", "a |> Kernel.-() |> c()"
+      assert_style "a |> then(&(+&1)) |> c", "a |> Kernel.+() |> c()"
+
       assert_style "a |> then(&fun(d, &1)) |> c()"
       assert_style "a |> then(&fun(&1, d, %{foo: &1})) |> c()"
     end


### PR DESCRIPTION
I _guess_ that's the only operators that need tweaking? feel free to take over the PR :)