### PR TITLE
extract alias usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Improvements
 
-* blocks: invert if and unless with `!=` or `!==`, like we do for `!` and `not`. Closes #132
-* `@derive`: move `@derive`s before `defstruct|schema|embedded_schema` declarations (compiler warns when it follows)
+* `alias`: implement alias lifting (`Credo.Check.Design.AliasUsage`). lifts aliases of depth >=3 (`A.B.C...`) that are used more than once.
+  **this is a big one!** please report any issues :) #135
+* `if`/`unless`: invert if and unless with `!=` or `!==`, like we do for `!` and `not` #132
+* `@derive`: move `@derive` before `defstruct|schema|embedded_schema` declarations (fixes compiler warning!) #134
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Disabling the rules means updating your `.credo.exs` depending on your configura
 {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
 # including `case`, `fn` and `with` statements
 {Credo.Check.Consistency.ParameterPatternMatching, false},
+# Styler implements this rule with a depth of 3 and minimum repetition of 2
+{Credo.Check.Design.AliasUsage, false},
 {Credo.Check.Readability.AliasOrder, false},
 {Credo.Check.Readability.BlockPipe, false},
 # goes further than formatter - fixes bad underscores, eg: `100_00` -> `10_000`

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -25,6 +25,7 @@ defmodule Styler.Style.ModuleDirectives do
     * `Credo.Check.Readability.MultiAlias`
     * `Credo.Check.Readability.StrictModuleLayout` (see section below for details)
     * `Credo.Check.Readability.UnnecessaryAliasExpansion`
+    * `Credo.Check.Design.AliasUsage`
 
   ## Strict Layout
 

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -240,8 +240,11 @@ defmodule Styler.Style.ModuleDirectives do
     liftable = find_liftable_aliases(requires ++ nondirectives, excluded)
 
     if Enum.any?(liftable) do
-      # TODO this'll move comments, need a repro
-      new_aliases = Enum.map(liftable, &{:alias, [line: 0], [{:__aliases__, [last: [line: 0], line: 0], &1}]})
+      # This is a silly hack that helps comments stay put.
+      # the `cap_line` algo was designed to handle high-line stuff moving up into low line territory, so we set our
+      # new node to have an abritrarily high line annnnd comments behave! i think.
+      line = 99_999
+      new_aliases = Enum.map(liftable, &{:alias, [line: line], [{:__aliases__, [last: [line: line], line: line], &1}]})
       aliases = expand_and_sort(aliases ++ new_aliases)
       requires = do_lift_aliases(requires, liftable)
       nondirectives = do_lift_aliases(nondirectives, liftable)

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -229,7 +229,15 @@ defmodule Styler.Style.ModuleDirectives do
   end
 
   defp lift_aliases(aliases, requires, nondirectives) do
-    liftable = find_liftable_aliases(requires ++ nondirectives, aliases)
+    excluded =
+      Enum.reduce(aliases, @stdlib, fn
+        {:alias, _, [{:__aliases__, _, aliases}]}, excluded -> MapSet.put(excluded, List.last(aliases))
+        {:alias, _, [{:__aliases__, _, _}, [{_as, {:__aliases__, _, [as]}}]]}, excluded -> MapSet.put(excluded, as)
+        # `alias __MODULE__` or other oddities
+        {:alias, _, _}, excluded -> excluded
+      end)
+
+    liftable = find_liftable_aliases(requires ++ nondirectives, excluded)
 
     if Enum.any?(liftable) do
       # TODO this'll move comments, need a repro
@@ -243,34 +251,39 @@ defmodule Styler.Style.ModuleDirectives do
     end
   end
 
-  defp find_liftable_aliases(ast, aliases) do
-    excluded =
-      Enum.reduce(aliases, @stdlib, fn
-        {:alias, _, [{:__aliases__, _, aliases}]}, excludes -> MapSet.put(excludes, List.last(aliases))
-        {:alias, _, [{:__aliases__, _, _}, [{_as, {:__aliases__, _, [as]}}]]}, excludes -> MapSet.put(excludes, as)
-        # `alias __MODULE__` or other oddities
-        {:alias, _, _}, excludes -> excludes
-      end)
-
+  defp find_liftable_aliases(ast, excluded) do
     ast
     |> Zipper.zip()
-    |> Zipper.traverse_while(%{}, fn
-      {{defx, _, _}, _} = zipper, acc when defx in ~w(defmodule defimpl defprotocol)a ->
+    |> Zipper.reduce_while({%{}, excluded}, fn
+      # we don't want to rewrite alias name `defx Aliases ... do` of these three keywords
+      {{defx, _, args}, _} = zipper, {lifts, excluded} = acc when defx in ~w(defmodule defimpl defprotocol)a ->
+        # don't conflict with submodules, which elixir automatically aliases
+        # we could've done this earlier when building excludes from aliases, but this gets it done without two traversals.
+        acc =
+          case args do
+            [{:__aliases__, _, aliases} | _] when defx == :defmodule ->
+              aliased = List.last(aliases)
+              {Map.delete(lifts, aliased), MapSet.put(excluded, aliased)}
+
+            _ ->
+              acc
+          end
+
         # move the focus to the body block, zkipping over the alias (and the `for` keyword for `defimpl`)
         {:skip, zipper |> Zipper.down() |> Zipper.rightmost() |> Zipper.down() |> Zipper.down(), acc}
 
       {{:quote, _, _}, _} = zipper, acc ->
         {:skip, zipper, acc}
 
-      {{:__aliases__, _, [_, _, _ | _] = aliases}, _} = zipper, acc ->
+      {{:__aliases__, _, [_, _, _ | _] = aliases}, _} = zipper, {lifts, excluded} = acc ->
         if List.last(aliases) in excluded or not Enum.all?(aliases, &is_atom/1),
           do: {:skip, zipper, acc},
-          else: {:skip, zipper, Map.update(acc, aliases, false, fn _ -> true end)}
+          else: {:skip, zipper, {Map.update(lifts, aliases, false, fn _ -> true end), excluded}}
 
       zipper, acc ->
         {:cont, zipper, acc}
     end)
-    |> elem(1)
+    |> elem(0)
     # if we have `Foo.Bar.Baz` and `Foo.Bar.Bop.Baz` both not aliased, we'll create a collision by lifting both
     # grouping by last alias lets us detect these collisions
     |> Enum.group_by(fn {aliases, _} -> List.last(aliases) end)

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -281,7 +281,7 @@ defmodule Styler.Style.ModuleDirectives do
     |> MapSet.new(fn {_, [{aliases, _}]} -> aliases end)
   end
 
-  defp do_lift_aliases(ast, new_aliases) do
+  defp do_lift_aliases(ast, to_alias) do
     ast
     |> Zipper.zip()
     |> Zipper.traverse(fn
@@ -291,12 +291,12 @@ defmodule Styler.Style.ModuleDirectives do
 
       {{:alias, _, [{:__aliases__, _, [_, _, _ | _] = aliases}]}, _} = zipper ->
         # the alias was aliased deeper down. we've lifted that alias to a root, so delete this alias
-        if aliases in new_aliases,
+        if aliases in to_alias,
           do: Zipper.remove(zipper),
           else: zipper
 
       {{:__aliases__, meta, [_, _, _ | _] = aliases}, _} = zipper ->
-        if aliases in new_aliases,
+        if aliases in to_alias,
           do: Zipper.replace(zipper, {:__aliases__, meta, [List.last(aliases)]}),
           else: zipper
 

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -124,7 +124,7 @@ defmodule Styler.Zipper do
     {leftmost, %{meta | l: [], r: r}}
   end
 
-  def leftmost(zipper), do: zipper
+  def leftmost({_, _} = zipper), do: zipper
 
   @doc """
   Returns the zipper of the right sibling of the node at this zipper, or nil.
@@ -142,7 +142,7 @@ defmodule Styler.Zipper do
     {rightmost, %{meta | l: l, r: []}}
   end
 
-  def rightmost(zipper), do: zipper
+  def rightmost({_, _} = zipper), do: zipper
 
   @doc """
   Replaces the current node in the zipper with a new node.

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -79,6 +79,29 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
     """
   end
 
+  describe "comments stay put" do
+    test "comments before alias stanza" do
+      assert_style(
+        """
+        # Foo is my fave
+        import Foo
+
+        A.B.C.f()
+        A.B.C.f()
+        """,
+        """
+        # Foo is my fave
+        import Foo
+
+        alias A.B.C
+
+        C.f()
+        C.f()
+        """
+      )
+    end
+  end
+
   describe "it doesn't lift" do
     test "collisions with std lib" do
       assert_style """

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -120,6 +120,23 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
     end
 
+    test "collisions with submodules" do
+      assert_style """
+      defmodule A do
+        @moduledoc false
+
+        A.B.C.f()
+
+        defmodule C do
+          @moduledoc false
+          A.B.C.f()
+        end
+
+        A.B.C.f()
+      end
+      """
+    end
+
     test "defprotocol, defmodule, or defimpl" do
       assert_style """
       defmodule No do

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -55,7 +55,17 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       end
     end
 
-    test "collisions with other lifts"
+    test "collisions with other lifts" do
+      assert_style """
+      defmodule NuhUh do
+        @moduledoc false
+
+        A.B.C.f()
+        A.B.C.f()
+        X.Y.C.f()
+      end
+      """
+    end
 
     test "defprotocol, defmodule, or defimpl" do
       assert_style """

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -1,0 +1,110 @@
+# Copyright 2023 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
+  @moduledoc false
+  use Styler.StyleCase, async: true
+
+  test "lifts aliases repeated >=2 times from 3 deep" do
+    assert_style(
+      """
+      defmodule A do
+        @moduledoc false
+
+        @spec bar :: A.B.C.t()
+        def bar do
+          A.B.C.f()
+        end
+      end
+      """,
+      """
+      defmodule A do
+        @moduledoc false
+
+        alias A.B.C
+
+        @spec bar :: C.t()
+        def bar do
+          C.f()
+        end
+      end
+      """
+    )
+  end
+
+  describe "it doesn't lift" do
+    test "defprotocol, defmodule, or defimpl" do
+      assert_style """
+      defmodule No do
+        @moduledoc false
+
+        defprotocol A.B.C do
+          :body
+        end
+
+        A.B.C.f()
+      end
+      """
+
+      assert_style """
+      defmodule No do
+        @moduledoc false
+        alias A.B.C
+
+        defprotocol A.B.C do
+          :body
+        end
+
+        C.f()
+        C.f()
+      end
+      """
+
+      assert_style """
+      defmodule No do
+        @moduledoc false
+
+        defmodule A.B.C do
+          @moduledoc false
+          :body
+        end
+
+        A.B.C.f()
+      end
+      """
+
+      assert_style """
+      defmodule No do
+        @moduledoc false
+
+        defimpl A.B.C, for: A.B.C do
+          :body
+        end
+
+        A.B.C.f()
+      end
+      """
+    end
+
+    test "quoted sections" do
+      assert_style """
+      defmodule A do
+        @moduledoc false
+        defmacro __using__(_) do
+          quote do
+            A.B.C.f()
+            A.B.C.f()
+          end
+        end
+      end
+      """
+    end
+  end
+end

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -40,6 +40,23 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
   end
 
   describe "it doesn't lift" do
+    test "collisions with aliases" do
+      for alias_c <- ["alias A.C", "alias A.B, as: C"] do
+        assert_style """
+        defmodule NuhUh do
+          @moduledoc false
+
+          #{alias_c}
+
+          A.B.C.f()
+          A.B.C.f()
+        end
+        """
+      end
+    end
+
+    test "collisions with other lifts"
+
     test "defprotocol, defmodule, or defimpl" do
       assert_style """
       defmodule No do

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -156,6 +156,26 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
         """
       )
     end
+
+    test "comments after alias stanza" do
+      assert_style(
+        """
+        # Foo is my fave
+        require Foo
+
+        A.B.C.f()
+        A.B.C.f()
+        """,
+        """
+        alias A.B.C
+        # Foo is my fave
+        require Foo
+
+        C.f()
+        C.f()
+        """
+      )
+    end
   end
 
   describe "it doesn't lift" do

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -133,19 +133,34 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       end
       """
 
-      assert_style """
-      defmodule No do
-        @moduledoc false
-        alias A.B.C
+      assert_style(
+        """
+        defmodule No do
+          @moduledoc false
 
-        defprotocol A.B.C do
-          :body
+          defimpl A.B.C, for: A.B.C do
+            :body
+          end
+
+          A.B.C.f()
+          A.B.C.f()
         end
+        """,
+        """
+        defmodule No do
+          @moduledoc false
 
-        C.f()
-        C.f()
-      end
-      """
+          alias A.B.C
+
+          defimpl A.B.C, for: A.B.C do
+            :body
+          end
+
+          C.f()
+          C.f()
+        end
+        """
+      )
 
       assert_style """
       defmodule No do


### PR DESCRIPTION
Write a Styler style that does the work of `Credo.Check.Design.AliasUsage`, lifting deeply nested aliases by `alias`ing them.

Notably, even if you're running credo's AliasUsage, styler will fix a _lot_ more things. 
This is because styler is fixing things that credo ignores:

1. credo ignores `@module_attribute A.B.C.f()` due to a mistaken report that dialyzer can't understand aliases
2. credo _only_ looks for deep modules being _invoked_. `apply(A.B.C, :f, [])` doesn't set credo off. (credo does complain if the module is the _only_ argument to a function call)

Yes, I thought of at least [_some_](https://github.com/adobe/elixir-styler/pull/135/files#diff-4b219d591161863697d29f166f2980252d9b96b7f8fb045c61af1ef3e9c9e9deR181) of the cases where it _shouldn't_ do that and implemented safeguards :)

🚢 :shipit: 

pretty sure this really will need configuration options to add more excluded namespaces than the stdlib (Plug for instance), but i'm merging to main as is and will do that as its own followup since it touches Styler itself

- [ ] FUTURE WORK add a configuration option to prevent conflict with libraries `styler: [alias_lifting_exclude: [Plug, GetText, ...]]`
- [x] rewrite all aliases? Credo only warns on function calls, or if the alias [_is the only argument_ to a function call](https://github.com/rrrene/credo/commit/969601966397c8cecdcdeac5c71fca402c4a278e) - the intention was to warn on any alias being used as an arg (... why arg?).  i had all aliases rewriting for a bit, but you maybe need to carve out exemptions (dont go into `quote` blocks)
- [x] dont go into `quote` blocks ?
- [x] don't extract aliases with unquotes in them
- [x] assert new aliases don't move comments
- [x] there's a bug where submodules can hit conflicts