### PR TITLE
rewrite double quote strings with many escapes to use `~s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   **this is a big one!** please report any issues :) #135
 * `if`/`unless`: invert if and unless with `!=` or `!==`, like we do for `!` and `not` #132
 * `@derive`: move `@derive` before `defstruct|schema|embedded_schema` declarations (fixes compiler warning!) #134
+* strings: rewrite double-quoted strings to use `~s` when there's 4+ escaped double-quotes
+  (`"\"\"\"\""` -> `~s("""")`) (`Credo.Check.Readability.StringSigils`) #146
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Disabling the rules means updating your `.credo.exs` depending on your configura
 {Credo.Check.Readability.SinglePipe, false},
 # **potentially breaks compilation** - see **Troubleshooting** section below
 {Credo.Check.Readability.StrictModuleLayout, false},
+{Credo.Check.Readability.StringSigils, false},
 {Credo.Check.Readability.UnnecessaryAliasExpansion, false},
 {Credo.Check.Readability.WithSingleClause, false},
 {Credo.Check.Refactor.CaseTrivialMatches, false},

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -19,6 +19,22 @@ defmodule Styler.Style.SingleNodeTest do
     end
   end
 
+  test "string sigil rewrites" do
+    assert_style ~s|""|
+    assert_style ~s|"\\""|
+    assert_style ~s|"\\"\\""|
+    assert_style ~s|"\\"\\"\\""|
+    assert_style ~s|"\\"\\"\\"\\""|, ~s|~s("""")|
+    # choose closing delimiter wisely, based on what has the least conflicts, in the styliest order
+    assert_style ~s/"\\"\\"\\"\\" )"/, ~s/~s{"""" )}/
+    assert_style ~s/"\\"\\"\\"\\" })"/, ~s/~s|"""" })|/
+    assert_style ~s/"\\"\\"\\"\\" |})"/, ~s/~s["""" |})]/
+    assert_style ~s/"\\"\\"\\"\\" ]|})"/, ~s/~s'"""" ]|})'/
+    assert_style ~s/"\\"\\"\\"\\" ']|})"/, ~s/~s<"""" ']|})>/
+    assert_style ~s/"\\"\\"\\"\\" >']|})"/, ~s|~s/"""" >']\|})/|
+    assert_style ~s/"\\"\\"\\"\\" \/>']|})"/, ~s|~s("""" />']\|}\\))|
+  end
+
   test "{Map/Keyword}.merge with a single static key" do
     for module <- ~w(Map Keyword) do
       assert_style("#{module}.merge(foo, %{one_key: :bar})", "#{module}.put(foo, :one_key, :bar)")


### PR DESCRIPTION
styler rewriting strings with many escapes involves running regexes against all string literals to detect too many escapes. was worried regexing like that would be too costly but… i think 3/100ths of a second in a repo as large as we have at frame is acceptable?

```sh
➜  frameio git:(me/styler-test) hyperfine 'mix format' -i --warmup 1 # with string sigils
Benchmark 1: mix format
  Time (mean ± σ):      3.589 s ±  0.024 s    [User: 16.577 s, System: 1.975 s]
  Range (min … max):    3.556 s …  3.638 s    10 runs

➜  frameio git:(me/styler-test) hyperfine 'mix format' -i --warmup 1 # without string sigils
Benchmark 1: mix format
  Time (mean ± σ):      3.553 s ±  0.027 s    [User: 16.527 s, System: 1.977 s]
  Range (min … max):    3.516 s …  3.602 s    10 runs
```