### PR TITLE
Fix piped `then` for complex expressions with division by one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ like shrinking function heads down to a single line when possible - that Credo d
 
 Ultimately, the best way to see what Styler does is to just try it out! What could go wrong? (You're using version control, right?)
 
+If you only want to use a specific combination of styles, they can be enabled individually via the `:enable` option within `:styler` in your `.formatter.exs` file, e.g.:
+```elixir
+...
+plugins: [Styler],
+styler: [
+  enable: [:defs, :module_directives]
+],
+...
+
+```
+
 ### Credo Rules Styler Replaces
 
 If you're using Credo and Styler, **we recommend disabling these rules in `.credo.exs`** to save on unnecessary checks in CI.

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -189,7 +189,7 @@ defmodule Styler.Style.Pipes do
 
   # a |> then(&fun/1) |> c => a |> fun() |> c()
   # recurses to add the `()` to `fun` as it gets unwound
-  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [fun, {:__block__, _, [1]}]}]}]}]}),
+  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [{_, _, nil} = fun, {:__block__, _, [1]}]}]}]}]}),
     do: fix_pipe({:|>, m, [lhs, fun]})
 
   # Credo.Check.Readability.PipeIntoAnonymousFunctions

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -30,7 +30,8 @@ defmodule Styler.Style.BlocksTest do
           # b
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -50,7 +51,8 @@ defmodule Styler.Style.BlocksTest do
           # b
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -69,7 +71,8 @@ defmodule Styler.Style.BlocksTest do
         end
 
         # b
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -83,7 +86,8 @@ defmodule Styler.Style.BlocksTest do
         if foo do
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -102,7 +106,8 @@ defmodule Styler.Style.BlocksTest do
           Logger.warning("it's false")
           nil
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -126,7 +131,8 @@ defmodule Styler.Style.BlocksTest do
           # a
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -148,7 +154,8 @@ defmodule Styler.Style.BlocksTest do
           # a
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -168,7 +175,8 @@ defmodule Styler.Style.BlocksTest do
           # a
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -234,7 +242,8 @@ defmodule Styler.Style.BlocksTest do
           # e
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
     end
   end
@@ -266,7 +275,8 @@ defmodule Styler.Style.BlocksTest do
           )
 
         y()
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -282,7 +292,8 @@ defmodule Styler.Style.BlocksTest do
         c = d()
         e = f()
         g
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -305,7 +316,8 @@ defmodule Styler.Style.BlocksTest do
         e = f()
         g
         y()
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -317,10 +329,11 @@ defmodule Styler.Style.BlocksTest do
         end
         """,
         """
-        def run do
+        def run() do
           arg
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -335,7 +348,8 @@ defmodule Styler.Style.BlocksTest do
         fn ->
           arg
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -355,7 +369,8 @@ defmodule Styler.Style.BlocksTest do
             g
           )
         )
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -380,7 +395,8 @@ defmodule Styler.Style.BlocksTest do
           weeee()
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -397,10 +413,11 @@ defmodule Styler.Style.BlocksTest do
         """
         case foo do
           :ok -> :success
-          :error = error -> error
+          error = :error -> error
           :fail -> :failure
         end
-        """
+        """,
+        enable: :blocks
       )
 
       for nontrivial_head <- ["foo", ":ok = foo", ":ok <- foo, :ok <- bar"] do
@@ -418,7 +435,8 @@ defmodule Styler.Style.BlocksTest do
         with :ok <- foo(),
           do: :ok
         """,
-        "foo()"
+        "foo()",
+        enable: :blocks
       )
     end
 
@@ -442,7 +460,8 @@ defmodule Styler.Style.BlocksTest do
           foo = bar
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -473,7 +492,8 @@ defmodule Styler.Style.BlocksTest do
           bar
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -496,7 +516,8 @@ defmodule Styler.Style.BlocksTest do
         else
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
 
       # no pre or postroll
@@ -514,7 +535,8 @@ defmodule Styler.Style.BlocksTest do
         else
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
 
       # with postroll
@@ -533,7 +555,8 @@ defmodule Styler.Style.BlocksTest do
         else
           :error
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -549,7 +572,8 @@ defmodule Styler.Style.BlocksTest do
           bar()
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -571,7 +595,8 @@ defmodule Styler.Style.BlocksTest do
         with {:ok, _} <- woo() do
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -605,7 +630,8 @@ defmodule Styler.Style.BlocksTest do
             DB.Repo.one(query, timeout: bar[\"timeout\"])
           end
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -622,7 +648,8 @@ defmodule Styler.Style.BlocksTest do
           shifted_datetime = DateTime.shift_zone!(datetime, full_name)
           Calendar.strftime(shifted_datetime, \"%Y/%m/%d - %I:%M %p\")
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -644,7 +671,8 @@ defmodule Styler.Style.BlocksTest do
           boop
           :horay!
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -661,7 +689,8 @@ defmodule Styler.Style.BlocksTest do
           boop
           :horay!
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -679,7 +708,8 @@ defmodule Styler.Style.BlocksTest do
         with {:ok, a} <- foo() do
           bar(a)
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style("""
@@ -713,7 +743,8 @@ defmodule Styler.Style.BlocksTest do
           bop()
           :ok
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -746,7 +777,8 @@ defmodule Styler.Style.BlocksTest do
         else
           c
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -771,13 +803,17 @@ defmodule Styler.Style.BlocksTest do
 
   describe "if/unless" do
     test "drops if else nil" do
-      assert_style("if a, do: b, else: nil", "if a, do: b")
+      assert_style("if a, do: b, else: nil", "if a, do: b", enable: :blocks)
 
-      assert_style("if a do b else nil end", """
-      if a do
-        b
-      end
-      """)
+      assert_style(
+        "if a do b else nil end",
+        """
+        if a do
+          b
+        end
+        """,
+        enable: :blocks
+      )
     end
 
     test "if not => unless" do
@@ -802,7 +838,8 @@ defmodule Styler.Style.BlocksTest do
           else
             c
           end
-          """
+          """,
+          enable: :blocks
         )
       end
 
@@ -821,7 +858,8 @@ defmodule Styler.Style.BlocksTest do
           else
             c
           end
-          """
+          """,
+          enable: :blocks
         )
       end
 
@@ -839,7 +877,8 @@ defmodule Styler.Style.BlocksTest do
         else
           b
         end
-        """
+        """,
+        enable: :blocks
       )
     end
 
@@ -857,12 +896,13 @@ defmodule Styler.Style.BlocksTest do
           if foo do
             bar
           end
-          """
+          """,
+          enable: :blocks
         )
       end
 
       for negator <- ["!=", "!=="], inverse = String.replace(negator, "!", "=") do
-        assert_style("unless a #{negator} b, do: :bar", "if a #{inverse} b, do: :bar")
+        assert_style("unless a #{negator} b, do: :bar", "if a #{inverse} b, do: :bar", enable: :blocks)
 
         assert_style(
           """
@@ -874,7 +914,8 @@ defmodule Styler.Style.BlocksTest do
           if a #{inverse} b do
             c
           end
-          """
+          """,
+          enable: :blocks
         )
       end
     end
@@ -897,7 +938,8 @@ defmodule Styler.Style.BlocksTest do
           else
             bar
           end
-          """
+          """,
+          enable: :blocks
         )
       end
 
@@ -918,7 +960,8 @@ defmodule Styler.Style.BlocksTest do
           else
             bar
           end
-          """
+          """,
+          enable: :blocks
         )
       end
     end
@@ -938,7 +981,8 @@ defmodule Styler.Style.BlocksTest do
         else
           b
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style(
@@ -955,7 +999,8 @@ defmodule Styler.Style.BlocksTest do
         else
           b
         end
-        """
+        """,
+        enable: :blocks
       )
 
       assert_style("if not (a != b), do: c", "if a == b, do: c")
@@ -980,7 +1025,8 @@ defmodule Styler.Style.BlocksTest do
           # b
           b
         end
-        """
+        """,
+        enable: :blocks
       )
     end
   end

--- a/test/style/configs_test.exs
+++ b/test/style/configs_test.exs
@@ -53,7 +53,8 @@ defmodule Styler.Style.ConfigsTest do
       config :y, :x, :z
 
       config :z, :x, :c
-      """
+      """,
+      enable: :configs
     )
   end
 
@@ -86,7 +87,6 @@ defmodule Styler.Style.ConfigsTest do
       """,
       """
       import Config
-
       dog_sound = :woof
       c = :c
 
@@ -116,7 +116,8 @@ defmodule Styler.Style.ConfigsTest do
       config :a, :b, a_sad_overwrite_that_will_be_hard_to_notice
 
       config :z, a: :meow
-      """
+      """,
+      enable: :configs
     )
   end
 
@@ -170,7 +171,8 @@ defmodule Styler.Style.ConfigsTest do
         # b comment
         config :b, 1
         config :b, 2
-        """
+        """,
+        enable: :configs
       )
     end
 
@@ -216,7 +218,6 @@ defmodule Styler.Style.ConfigsTest do
         """,
         """
         import Config
-
         dog_sound = :woof
 
         # this is my big c
@@ -260,7 +261,8 @@ defmodule Styler.Style.ConfigsTest do
         config :a, :b, a_sad_overwrite_that_will_be_hard_to_notice
 
         config :z, a: :meow
-        """
+        """,
+        enable: :configs
       )
     end
 
@@ -347,7 +349,8 @@ defmodule Styler.Style.ConfigsTest do
           cd: :cd
 
         # end of config
-        """
+        """,
+        enable: :configs
       )
     end
   end

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -47,7 +47,8 @@ defmodule Styler.Style.DefsTest do
         # Socket comment
         # Params comment
         def save(%Socket{assigns: %{user: user, live_action: :new}} = initial_socket, params), do: :ok
-        """
+        """,
+        enable: :defs
       )
     end
 
@@ -93,7 +94,8 @@ defmodule Styler.Style.DefsTest do
         def save(%Socket{assigns: %{user: user, live_action: :new}} = initial_socket, params) do
           :ok
         end
-        """
+        """,
+        enable: :defs
       )
     end
 
@@ -117,7 +119,8 @@ defmodule Styler.Style.DefsTest do
 
         # Another comment for this head
         def no_body(nil, _), do: nil
-        """
+        """,
+        enable: :defs
       )
     end
 
@@ -139,7 +142,8 @@ defmodule Styler.Style.DefsTest do
         # Obviously, this is a
         # ... and this is b
         def foo(%{bar: baz}) when baz in [:a, :b], do: :never_write_code_like_this
-        """
+        """,
+        enable: :defs
       )
     end
 
@@ -155,7 +159,8 @@ defmodule Styler.Style.DefsTest do
         """
         # Weirdo comment
         def foo, do: [:never_write_code_like_this]
-        """
+        """,
+        enable: :defs
       )
     end
 
@@ -171,11 +176,12 @@ defmodule Styler.Style.DefsTest do
         ), do: :ok
         """,
         """
-        def foo, do: :ok
+        def foo(), do: :ok
 
         # Long long is too long
         def foo(too, long), do: :ok
-        """
+        """,
+        enable: :defs
       )
     end
 
@@ -206,7 +212,8 @@ defmodule Styler.Style.DefsTest do
           :never_write_code_like_this
           # Below the body
         end
-        """
+        """,
+        enable: :defs
       )
     end
 

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -42,7 +42,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           alias Foo.A
           alias Foo.B
         end
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -56,7 +57,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule A do
           @moduledoc false
         end
-        """
+        """,
+        enable: :module_directives
       )
 
       assert_style(
@@ -73,7 +75,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
             @moduledoc false
           end
         end
-        """
+        """,
+        enable: :module_directives
       )
 
       assert_style(
@@ -91,7 +94,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
           :ok
         end
-        """
+        """,
+        enable: :module_directives
       )
 
       assert_style(
@@ -104,7 +108,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule DocsOnly do
           @moduledoc "woohoo"
         end
-        """
+        """,
+        enable: :module_directives
       )
 
       assert_style(
@@ -118,7 +123,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           @moduledoc false
           use Bar
         end
-        """
+        """,
+        enable: :module_directives
       )
 
       assert_style(
@@ -133,7 +139,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           alias Foo.Bar
           alias Foo.Baz
         end
-        """
+        """,
+        enable: :module_directives
       )
 
       assert_style(
@@ -153,7 +160,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
             :literal
           end
         end
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -250,7 +258,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
             X.foo()
           end
         end
-        """
+        """,
+        enable: :module_directives
       )
     end
   end
@@ -289,7 +298,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           alias A.B
           alias A.C
         end
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -318,7 +328,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           import A
           import B
         end
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -349,7 +360,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           #{d} A.C
           #{d} B.B
           #{d} D.D
-          """
+          """,
+          enable: :module_directives
         )
       end
     end
@@ -362,7 +374,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """
         alias __MODULE__.A
         alias __MODULE__.B.D
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -384,7 +397,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         use A.B
 
         import F
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -422,7 +436,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         require A.C
 
         @type foo :: :ok
-        """
+        """,
+        enable: :module_directives
       )
     end
 
@@ -475,7 +490,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
           # C
           # A
         end
-        """
+        """,
+        enable: :module_directives
       )
     end
   end
@@ -489,7 +505,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
       Foo.bar()
       """,
-      "Foo.bar()"
+      "Foo.bar()",
+      enable: :module_directives
     )
 
     assert_style(
@@ -503,7 +520,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
       alias __MODULE__
       alias Bar, as: Bop
       alias unquote(Foo)
-      """
+      """,
+      enable: :module_directives
     )
 
     assert_style(
@@ -519,7 +537,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
       alias B.B
 
       require D
-      """
+      """,
+      enable: :module_directives
     )
   end
 
@@ -543,7 +562,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         # comment for foo
         def foo, do: :ok
       end
-      """
+      """,
+      enable: :module_directives
     )
 
     assert_style "@derive Inspect"
@@ -581,7 +601,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         alias G.H.C
         alias Z.X.C
       end
-      """
+      """,
+      enable: :module_directives
     )
   end
 end

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -501,6 +501,7 @@ defmodule Styler.Style.PipesTest do
     test "rewrites then/2 when the passed function is a named function reference" do
       assert_style "a |> then(&fun/1) |> c", "a |> fun() |> c()"
       assert_style "a |> then(&(&1 / 1)) |> c", "a |> Kernel./(1) |> c()"
+      assert_style "a |> then(&(&1 * 2 / 1)) |> c()"
       assert_style "a |> then(&fun/1)", "fun(a)"
       assert_style "a |> then(&fun(&1)) |> c", "a |> fun() |> c()"
       assert_style "a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()"

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -13,7 +13,7 @@ defmodule Styler.Style.PipesTest do
 
   describe "big picture" do
     test "unnests multiple steps" do
-      assert_style("f(g(h(x))) |> j()", "x |> h() |> g() |> f() |> j()")
+      assert_style("f(g(h(x))) |> j()", "x |> h() |> g() |> f() |> j()", enable: :pipes)
     end
 
     test "doesn't modify valid pipe" do
@@ -38,7 +38,8 @@ defmodule Styler.Style.PipesTest do
         |> M.f(b)
         |> g()
         |> h()
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -75,7 +76,8 @@ defmodule Styler.Style.PipesTest do
           |> baz()
         end)
         |> c()
-        """
+        """,
+        enable: :pipes
       )
     end
   end
@@ -118,7 +120,8 @@ defmodule Styler.Style.PipesTest do
           end
 
         IO.puts(foo_result)
-        """
+        """,
+        enable: :pipes
       )
 
       assert_style(
@@ -139,7 +142,8 @@ defmodule Styler.Style.PipesTest do
           end
 
         IO.puts(foo_result)
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -164,7 +168,8 @@ defmodule Styler.Style.PipesTest do
           :ok -> :ok
           _ -> :error
         end
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -198,7 +203,8 @@ defmodule Styler.Style.PipesTest do
           case_result
           |> bar()
           |> baz()
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -215,7 +221,8 @@ defmodule Styler.Style.PipesTest do
         for_result
         |> bar()
         |> baz()
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -234,7 +241,8 @@ defmodule Styler.Style.PipesTest do
           end
 
         wee(unless_result)
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -251,7 +259,8 @@ defmodule Styler.Style.PipesTest do
         with_result
         |> bar()
         |> baz()
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -273,7 +282,8 @@ defmodule Styler.Style.PipesTest do
         cond_result
         |> bar()
         |> baz()
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -292,7 +302,8 @@ defmodule Styler.Style.PipesTest do
           end
 
         foo(case_result)
-        """
+        """,
+        enable: :pipes
       )
 
       assert_style(
@@ -313,7 +324,8 @@ defmodule Styler.Style.PipesTest do
 
           foo(case_result)
         end
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -339,7 +351,8 @@ defmodule Styler.Style.PipesTest do
           |> a()
           |> b()
         end
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -361,7 +374,8 @@ defmodule Styler.Style.PipesTest do
         quote_result
         |> bar()
         |> baz()
-        """
+        """,
+        enable: :pipes
       )
     end
   end
@@ -372,10 +386,10 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "fixes simple single pipes" do
-      assert_style("b(a) |> c()", "a |> b() |> c()")
-      assert_style("a |> f()", "f(a)")
-      assert_style("x |> bar", "bar(x)")
-      assert_style("def a, do: b |> c()", "def a, do: c(b)")
+      assert_style("b(a) |> c()", "a |> b() |> c()", enable: :pipes)
+      assert_style("a |> f()", "f(a)", enable: :pipes)
+      assert_style("x |> bar", "bar(x)", enable: :pipes)
+      assert_style("def a, do: b |> c()", "def a, do: c(b)", enable: :pipes)
     end
 
     test "keeps invocation on a single line" do
@@ -386,7 +400,8 @@ defmodule Styler.Style.PipesTest do
         """,
         """
         bar(foo, baz, bop, boom)
-        """
+        """,
+        enable: :pipes
       )
 
       assert_style(
@@ -396,7 +411,8 @@ defmodule Styler.Style.PipesTest do
         """,
         """
         bar(foo, baz)
-        """
+        """,
+        enable: :pipes
       )
 
       assert_style(
@@ -410,7 +426,8 @@ defmodule Styler.Style.PipesTest do
         def halt(exec, halt_message) do
           put_halt_message(%__MODULE__{exec | halted: true}, halt_message)
         end
-        """
+        """,
+        enable: :pipes
       )
 
       assert_style(
@@ -429,16 +446,17 @@ defmodule Styler.Style.PipesTest do
           end
 
         foo(if_result, bar)
-        """
+        """,
+        enable: :pipes
       )
     end
   end
 
   describe "valid pipe starts & unpiping" do
     test "writes brackets for unpiped kwl" do
-      assert_style("foo(kwl: :arg) |> bar()", "[kwl: :arg] |> foo() |> bar()")
-      assert_style("%{a: foo(a: :b, c: :d) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}")
-      assert_style("%{a: foo([a: :b, c: :d]) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}")
+      assert_style("foo(kwl: :arg) |> bar()", "[kwl: :arg] |> foo() |> bar()", enable: :pipes)
+      assert_style("%{a: foo(a: :b, c: :d) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}", enable: :pipes)
+      assert_style("%{a: foo([a: :b, c: :d]) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}", enable: :pipes)
     end
 
     test "allows fn" do
@@ -453,8 +471,8 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "recognizes infix ops as valid pipe starts" do
-      assert_style("(bar() == 1) |> foo()", "foo(bar() == 1)")
-      assert_style("(x in 1..100) |> foo()", "foo(x in 1..100)")
+      assert_style("(bar() == 1) |> foo()", "foo(bar() == 1)", enable: :pipes)
+      assert_style("(x in 1..100) |> foo()", "foo(x in 1..100)", enable: :pipes)
     end
 
     test "0 arity is just fine!" do
@@ -475,45 +493,47 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "ranges" do
-      assert_style("start..stop//step |> foo()", "foo(start..stop//step)")
+      assert_style("start..stop//step |> foo()", "foo(start..stop//step)", enable: :pipes)
       assert_style("start..stop//step |> foo() |> bar()")
-      assert_style("foo(start..stop//step) |> bar()", "start..stop//step |> foo() |> bar()")
+      assert_style("foo(start..stop//step) |> bar()", "start..stop//step |> foo() |> bar()", enable: :pipes)
     end
   end
 
   describe "simple rewrites" do
     test "{Keyword/Map}.merge/2 of a single key => *.put/3" do
       for module <- ~w(Map Keyword) do
-        assert_style("foo |> #{module}.merge(%{one_key: :bar}) |> bop()", "foo |> #{module}.put(:one_key, :bar) |> bop()")
+        assert_style("foo |> #{module}.merge(%{one_key: :bar}) |> bop()", "foo |> #{module}.put(:one_key, :bar) |> bop()",
+          enable: :pipes
+        )
       end
     end
 
     test "rewrites anon fun def ahd invoke to use then" do
-      assert_style("a |> (& &1).()", "then(a, & &1)")
-      assert_style("a |> (& {&1, &2}).(b)", "(&{&1, &2}).(a, b)")
-      assert_style("a |> (& &1).() |> c", "a |> then(& &1) |> c()")
+      assert_style("a |> (& &1).()", "then(a, & &1)", enable: :pipes)
+      assert_style("a |> (& {&1, &2}).(b)", "(&{&1, &2}).(a, b)", enable: :pipes)
+      assert_style("a |> (& &1).() |> c", "a |> then(& &1) |> c()", enable: :pipes)
 
-      assert_style("a |> (fn x, y -> {x, y} end).() |> c", "a |> then(fn x, y -> {x, y} end) |> c()")
-      assert_style("a |> (fn x -> x end).()", "then(a, fn x -> x end)")
-      assert_style("a |> (fn x -> x end).() |> c", "a |> then(fn x -> x end) |> c()")
+      assert_style("a |> (fn x, y -> {x, y} end).() |> c", "a |> then(fn x, y -> {x, y} end) |> c()", enable: :pipes)
+      assert_style("a |> (fn x -> x end).()", "then(a, fn x -> x end)", enable: :pipes)
+      assert_style("a |> (fn x -> x end).() |> c", "a |> then(fn x -> x end) |> c()", enable: :pipes)
     end
 
     test "rewrites then/2 when the passed function is a named function reference" do
-      assert_style "a |> then(&fun/1) |> c", "a |> fun() |> c()"
-      assert_style "a |> then(&(&1 / 1)) |> c", "a |> Kernel./(1) |> c()"
-      assert_style "a |> then(&(&1 * 2 / 1)) |> c()"
-      assert_style "a |> then(&fun/1)", "fun(a)"
-      assert_style "a |> then(&fun(&1)) |> c", "a |> fun() |> c()"
-      assert_style "a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()"
+      assert_style("a |> then(&fun/1) |> c", "a |> fun() |> c()", enable: :pipes)
+      assert_style("a |> then(&(&1 / 1)) |> c", "a |> Kernel./(1) |> c()", enable: :pipes)
+      assert_style "a |> then(&(&1 * 2 / 1)) |> c()", enable: :pipes
+      assert_style("a |> then(&fun/1)", "fun(a)", enable: :pipes)
+      assert_style("a |> then(&fun(&1)) |> c", "a |> fun() |> c()", enable: :pipes)
+      assert_style("a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()", enable: :pipes)
       assert_style "a |> then(&fun(d, &1)) |> c()"
       assert_style "a |> then(&fun(&1, d, %{foo: &1})) |> c()"
 
       # then + kernel ops
-      assert_style "a |> then(&(-&1)) |> c", "a |> Kernel.-() |> c()"
-      assert_style "a |> then(&(+&1)) |> c", "a |> Kernel.+() |> c()"
+      assert_style("a |> then(&(-&1)) |> c", "a |> Kernel.-() |> c()", enable: :pipes)
+      assert_style("a |> then(&(+&1)) |> c", "a |> Kernel.+() |> c()", enable: :pipes)
 
       for op <- ~w(++ -- && || in - * + / > < <= >= == and or != !== === <>) do
-        assert_style "a |> then(&(&1 #{op} x)) |> c", "a |> Kernel.#{op}(x) |> c()"
+        assert_style("a |> then(&(&1 #{op} x)) |> c", "a |> Kernel.#{op}(x) |> c()", enable: :pipes)
       end
 
       # Doesn't rewrite non-kernel operators
@@ -523,14 +543,14 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "adds parens to 1-arity pipes" do
-      assert_style("a |> b |> c", "a |> b() |> c()")
+      assert_style("a |> b |> c", "a |> b() |> c()", enable: :pipes)
     end
 
     test "reverse/concat" do
       assert_style("a |> Enum.reverse() |> Enum.concat()")
       assert_style("a |> Enum.reverse(bar) |> Enum.concat()")
       assert_style("a |> Enum.reverse(bar) |> Enum.concat(foo)")
-      assert_style("a |> Enum.reverse() |> Enum.concat(foo)", "Enum.reverse(a, foo)")
+      assert_style("a |> Enum.reverse() |> Enum.concat(foo)", "Enum.reverse(a, foo)", enable: :pipes)
 
       assert_style(
         """
@@ -543,7 +563,8 @@ defmodule Styler.Style.PipesTest do
         a
         |> Enum.reverse([bar, baz])
         |> Enum.sum()
-        """
+        """,
+        enable: :pipes
       )
     end
 
@@ -560,7 +581,8 @@ defmodule Styler.Style.PipesTest do
           a
           |> Enum.count(fun)
           |> IO.puts()
-          """
+          """,
+          enable: :pipes
         )
 
         assert_style(
@@ -571,7 +593,8 @@ defmodule Styler.Style.PipesTest do
           """,
           """
           Enum.count(a, fun)
-          """
+          """,
+          enable: :pipes
         )
 
         assert_style(
@@ -593,25 +616,27 @@ defmodule Styler.Style.PipesTest do
             end
 
           Enum.count(if_result, fun)
-          """
+          """,
+          enable: :pipes
         )
       end
     end
 
     test "map/join" do
       for enum <- ~w(Enum Stream) do
-        assert_style("a|> #{enum}.map(b) |> Enum.join(x)", "Enum.map_join(a, x, b)")
+        assert_style("a|> #{enum}.map(b) |> Enum.join(x)", "Enum.map_join(a, x, b)", enable: :pipes)
       end
     end
 
     test "map/into" do
       for enum <- ~w(Enum Stream) do
-        assert_style("a|> #{enum}.map(b)|> Enum.into(%{})", "Map.new(a, b)")
-        assert_style("a |> #{enum}.map(b) |> Enum.into(unk)", "Enum.into(a, unk, b)")
+        assert_style("a|> #{enum}.map(b)|> Enum.into(%{})", "Map.new(a, b)", enable: :pipes)
+        assert_style("a |> #{enum}.map(b) |> Enum.into(unk)", "Enum.into(a, unk, b)", enable: :pipes)
 
         assert_style(
           "a |> #{enum}.map(b) |> Enum.into(%{some: :existing_map})",
-          "Enum.into(a, %{some: :existing_map}, b)"
+          "Enum.into(a, %{some: :existing_map}, b)",
+          enable: :pipes
         )
 
         assert_style(
@@ -628,11 +653,12 @@ defmodule Styler.Style.PipesTest do
             IO.puts("woo!")
             {shrunk, to_a_more_reasonable}
           end)
-          """
+          """,
+          enable: :pipes
         )
 
         for collectable <- ~W(Map Keyword MapSet), new = "#{collectable}.new" do
-          assert_style("a |> #{enum}.map(b) |> Enum.into(#{new}())", "#{new}(a, b)")
+          assert_style("a |> #{enum}.map(b) |> Enum.into(#{new}())", "#{new}(a, b)", enable: :pipes)
 
           # Regression: something about the meta wants newlines when it's in a def
           assert_style(
@@ -642,10 +668,11 @@ defmodule Styler.Style.PipesTest do
             end
             """,
             """
-            def foo do
+            def foo() do
               filename_map = Map.new(foo, &{&1.filename, true})
             end
-            """
+            """,
+            enable: :pipes
           )
         end
       end
@@ -653,13 +680,13 @@ defmodule Styler.Style.PipesTest do
 
     test "map/new" do
       for collectable <- ~W(Map Keyword MapSet), new = "#{collectable}.new" do
-        assert_style("a |> Enum.map(b) |> #{new}()", "#{new}(a, b)")
+        assert_style("a |> Enum.map(b) |> #{new}()", "#{new}(a, b)", enable: :pipes)
       end
     end
 
     test "into(%{})" do
-      assert_style("a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()")
-      assert_style("a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()")
+      assert_style("a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()", enable: :pipes)
+      assert_style("a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()", enable: :pipes)
     end
 
     test "into(Collectable.new())" do
@@ -667,8 +694,8 @@ defmodule Styler.Style.PipesTest do
       assert_style("a |> Enum.into(foo, mapper) |> b()")
 
       for collectable <- ~W(Map Keyword MapSet), new = "#{collectable}.new" do
-        assert_style("a |> Enum.into(#{new}) |> b()", "a |> #{new}() |> b()")
-        assert_style("a |> Enum.into(#{new}, mapper) |> b()", "a |> #{new}(mapper) |> b()")
+        assert_style("a |> Enum.into(#{new}) |> b()", "a |> #{new}() |> b()", enable: :pipes)
+        assert_style("a |> Enum.into(#{new}, mapper) |> b()", "a |> #{new}(mapper) |> b()", enable: :pipes)
 
         assert_style(
           """
@@ -680,7 +707,8 @@ defmodule Styler.Style.PipesTest do
           a
           |> Enum.map(b)
           |> #{new}(c)
-          """
+          """,
+          enable: :pipes
         )
       end
     end
@@ -688,29 +716,32 @@ defmodule Styler.Style.PipesTest do
 
   describe "comments" do
     test "unpiping doens't move comment in anon fun" do
-      assert_style """
-                     aliased =
-                       aliases
-                       |> MapSet.new(fn
-                         {:alias, _, [{:__aliases__, _, aliases}]} -> List.last(aliases)
-                         {:alias, _, [{:__aliases__, _, _}, [{_as, {:__aliases__, _, [as]}}]]} -> as
-                         # alias __MODULE__ or other oddities
-                         {:alias, _, _} -> nil
-                       end)
+      assert_style(
+        """
+          aliased =
+            aliases
+            |> MapSet.new(fn
+              {:alias, _, [{:__aliases__, _, aliases}]} -> List.last(aliases)
+              {:alias, _, [{:__aliases__, _, _}, [{_as, {:__aliases__, _, [as]}}]]} -> as
+              # alias __MODULE__ or other oddities
+              {:alias, _, _} -> nil
+            end)
 
-                     excluded_first = MapSet.union(aliased, @excluded_namespaces)
-                   """,
-                   """
-                   aliased =
-                     MapSet.new(aliases, fn
-                       {:alias, _, [{:__aliases__, _, aliases}]} -> List.last(aliases)
-                       {:alias, _, [{:__aliases__, _, _}, [{_as, {:__aliases__, _, [as]}}]]} -> as
-                       # alias __MODULE__ or other oddities
-                       {:alias, _, _} -> nil
-                     end)
+          excluded_first = MapSet.union(aliased, @excluded_namespaces)
+        """,
+        """
+        aliased =
+          MapSet.new(aliases, fn
+            {:alias, _, [{:__aliases__, _, aliases}]} -> List.last(aliases)
+            {:alias, _, [{:__aliases__, _, _}, [{_as, {:__aliases__, _, [as]}}]]} -> as
+            # alias __MODULE__ or other oddities
+            {:alias, _, _} -> nil
+          end)
 
-                   excluded_first = MapSet.union(aliased, @excluded_namespaces)
-                   """
+        excluded_first = MapSet.union(aliased, @excluded_namespaces)
+        """,
+        enable: :pipes
+      )
     end
   end
 end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -16,21 +16,21 @@ defmodule Styler.Style.SingleNodeTest do
     assert_style ~s|"\\""|
     assert_style ~s|"\\"\\""|
     assert_style ~s|"\\"\\"\\""|
-    assert_style ~s|"\\"\\"\\"\\""|, ~s|~s("""")|
+    assert_style(~s|"\\"\\"\\"\\""|, ~s|~s("""")|, enable: :single_node)
     # choose closing delimiter wisely, based on what has the least conflicts, in the styliest order
-    assert_style ~s/"\\"\\"\\"\\" )"/, ~s/~s{"""" )}/
-    assert_style ~s/"\\"\\"\\"\\" })"/, ~s/~s|"""" })|/
-    assert_style ~s/"\\"\\"\\"\\" |})"/, ~s/~s["""" |})]/
-    assert_style ~s/"\\"\\"\\"\\" ]|})"/, ~s/~s'"""" ]|})'/
-    assert_style ~s/"\\"\\"\\"\\" ']|})"/, ~s/~s<"""" ']|})>/
-    assert_style ~s/"\\"\\"\\"\\" >']|})"/, ~s|~s/"""" >']\|})/|
-    assert_style ~s/"\\"\\"\\"\\" \/>']|})"/, ~s|~s("""" />']\|}\\))|
+    assert_style(~s/"\\"\\"\\"\\" )"/, ~s/~s{"""" )}/, enable: :single_node)
+    assert_style(~s/"\\"\\"\\"\\" })"/, ~s/~s|"""" })|/, enable: :single_node)
+    assert_style(~s/"\\"\\"\\"\\" |})"/, ~s/~s["""" |})]/, enable: :single_node)
+    assert_style(~s/"\\"\\"\\"\\" ]|})"/, ~s/~s'"""" ]|})'/, enable: :single_node)
+    assert_style(~s/"\\"\\"\\"\\" ']|})"/, ~s/~s<"""" ']|})>/, enable: :single_node)
+    assert_style(~s/"\\"\\"\\"\\" >']|})"/, ~s|~s/"""" >']\|})/|, enable: :single_node)
+    assert_style(~s/"\\"\\"\\"\\" \/>']|})"/, ~s|~s("""" />']\|}\\))|, enable: :single_node)
   end
 
   test "{Map/Keyword}.merge with a single static key" do
     for module <- ~w(Map Keyword) do
-      assert_style("#{module}.merge(foo, %{one_key: :bar})", "#{module}.put(foo, :one_key, :bar)")
-      assert_style("#{module}.merge(foo, one_key: :bar)", "#{module}.put(foo, :one_key, :bar)")
+      assert_style("#{module}.merge(foo, %{one_key: :bar})", "#{module}.put(foo, :one_key, :bar)", enable: :single_node)
+      assert_style("#{module}.merge(foo, one_key: :bar)", "#{module}.put(foo, :one_key, :bar)", enable: :single_node)
       # # doesn't rewrite if there's a custom merge strategy
       assert_style("#{module}.merge(foo, %{one_key: :bar}, custom_merge_strategy)")
       # # doesn't rewrite if > 1 key
@@ -40,8 +40,8 @@ defmodule Styler.Style.SingleNodeTest do
 
   describe "Timex.now/0,1" do
     test "Timex.now/0 => DateTime.utc_now/0" do
-      assert_style("Timex.now()", "DateTime.utc_now()")
-      assert_style("Timex.now() |> foo() |> bar()", "DateTime.utc_now() |> foo() |> bar()")
+      assert_style("Timex.now()", "DateTime.utc_now()", enable: :single_node)
+      assert_style("Timex.now() |> foo() |> bar()", "DateTime.utc_now() |> foo() |> bar()", enable: :single_node)
     end
 
     test "leaves Timex.now/1 alone" do
@@ -57,29 +57,30 @@ defmodule Styler.Style.SingleNodeTest do
         timezone
         |> Timex.now()
         |> foo()
-        """
+        """,
+        enable: :single_node
       )
     end
   end
 
   test "{DateTime,NaiveDateTime,Time,Date}.compare to {DateTime,NaiveDateTime,Time,Date}.before?" do
-    assert_style("DateTime.compare(foo, bar) == :lt", "DateTime.before?(foo, bar)")
-    assert_style("NaiveDateTime.compare(foo, bar) == :lt", "NaiveDateTime.before?(foo, bar)")
-    assert_style("Time.compare(foo, bar) == :lt", "Time.before?(foo, bar)")
-    assert_style("Date.compare(foo, bar) == :lt", "Date.before?(foo, bar)")
+    assert_style("DateTime.compare(foo, bar) == :lt", "DateTime.before?(foo, bar)", enable: :single_node)
+    assert_style("NaiveDateTime.compare(foo, bar) == :lt", "NaiveDateTime.before?(foo, bar)", enable: :single_node)
+    assert_style("Time.compare(foo, bar) == :lt", "Time.before?(foo, bar)", enable: :single_node)
+    assert_style("Date.compare(foo, bar) == :lt", "Date.before?(foo, bar)", enable: :single_node)
   end
 
   test "{DateTime,NaiveDateTime,Time,Date}.compare to {DateTime,NaiveDateTime,Time,Date}.after?" do
-    assert_style("DateTime.compare(foo, bar) == :gt", "DateTime.after?(foo, bar)")
-    assert_style("NaiveDateTime.compare(foo, bar) == :gt", "NaiveDateTime.after?(foo, bar)")
-    assert_style("Time.compare(foo, bar) == :gt", "Time.after?(foo, bar)")
-    assert_style("Time.compare(foo, bar) == :gt", "Time.after?(foo, bar)")
+    assert_style("DateTime.compare(foo, bar) == :gt", "DateTime.after?(foo, bar)", enable: :single_node)
+    assert_style("NaiveDateTime.compare(foo, bar) == :gt", "NaiveDateTime.after?(foo, bar)", enable: :single_node)
+    assert_style("Time.compare(foo, bar) == :gt", "Time.after?(foo, bar)", enable: :single_node)
+    assert_style("Time.compare(foo, bar) == :gt", "Time.after?(foo, bar)", enable: :single_node)
   end
 
   describe "def / defp" do
     test "0-arity functions have parens removed" do
-      assert_style("def foo(), do: :ok", "def foo, do: :ok")
-      assert_style("defp foo(), do: :ok", "defp foo, do: :ok")
+      assert_style("def foo(), do: :ok", "def foo, do: :ok", enable: :single_node)
+      assert_style("defp foo(), do: :ok", "defp foo, do: :ok", enable: :single_node)
 
       assert_style(
         """
@@ -91,7 +92,8 @@ defmodule Styler.Style.SingleNodeTest do
         def foo do
           :ok
         end
-        """
+        """,
+        enable: :single_node
       )
 
       assert_style(
@@ -104,7 +106,8 @@ defmodule Styler.Style.SingleNodeTest do
         defp foo do
           :ok
         end
-        """
+        """,
+        enable: :single_node
       )
 
       # Regression: be wary of invocations with extra parens from metaprogramming
@@ -141,7 +144,8 @@ defmodule Styler.Style.SingleNodeTest do
           after
             :done
           end
-          """
+          """,
+          enable: :single_node
         )
       end
     end
@@ -163,8 +167,11 @@ defmodule Styler.Style.SingleNodeTest do
 
   describe "RHS pattern matching" do
     test "left arrows" do
-      assert_style("with {:ok, result = %{}} <- foo, do: result", "with {:ok, %{} = result} <- foo, do: result")
-      assert_style("for map = %{} <- maps, do: map[:key]", "for %{} = map <- maps, do: map[:key]")
+      assert_style("with {:ok, result = %{}} <- foo, do: result", "with {:ok, %{} = result} <- foo, do: result",
+        enable: :single_node
+      )
+
+      assert_style("for map = %{} <- maps, do: map[:key]", "for %{} = map <- maps, do: map[:key]", enable: :single_node)
     end
 
     test "case statements" do
@@ -180,7 +187,8 @@ defmodule Styler.Style.SingleNodeTest do
           %{baz: true = baz?} = bar -> :baz?
           [[%{} = a] | _] = opts -> a
         end
-        """
+        """,
+        enable: :single_node
       )
     end
 
@@ -189,8 +197,8 @@ defmodule Styler.Style.SingleNodeTest do
     end
 
     test "removes a double-var assignment when one var is _" do
-      assert_style("def foo(_ = bar), do: bar", "def foo(bar), do: bar")
-      assert_style("def foo(bar = _), do: bar", "def foo(bar), do: bar")
+      assert_style("def foo(_ = bar), do: bar", "def foo(bar), do: bar", enable: :single_node)
+      assert_style("def foo(bar = _), do: bar", "def foo(bar), do: bar", enable: :single_node)
 
       assert_style(
         """
@@ -202,7 +210,8 @@ defmodule Styler.Style.SingleNodeTest do
         case foo do
           bar -> :ok
         end
-        """
+        """,
+        enable: :single_node
       )
 
       assert_style(
@@ -215,21 +224,24 @@ defmodule Styler.Style.SingleNodeTest do
         case foo do
           bar -> :ok
         end
-        """
+        """,
+        enable: :single_node
       )
     end
 
     test "defs" do
       assert_style(
         "def foo(bar = %{baz: baz? = true}, opts = [[a = %{}] | _]), do: :ok",
-        "def foo(%{baz: true = baz?} = bar, [[%{} = a] | _] = opts), do: :ok"
+        "def foo(%{baz: true = baz?} = bar, [[%{} = a] | _] = opts), do: :ok",
+        enable: :single_node
       )
     end
 
     test "anon funs" do
       assert_style(
         "fn bar = %{baz: baz? = true}, opts = [[a = %{}] | _] -> :ok end",
-        "fn %{baz: true = baz?} = bar, [[%{} = a] | _] = opts -> :ok end"
+        "fn %{baz: true = baz?} = bar, [[%{} = a] | _] = opts -> :ok end",
+        enable: :single_node
       )
     end
 
@@ -260,19 +272,20 @@ defmodule Styler.Style.SingleNodeTest do
           :error = error -> error
           other -> other
         end
-        """
+        """,
+        enable: :single_node
       )
     end
   end
 
   describe "numbers" do
     test "styles floats and integers with >4 digits" do
-      assert_style("10000", "10_000")
-      assert_style("1_0_0_0_0", "10_000")
-      assert_style("-543213", "-543_213")
-      assert_style("123456789", "123_456_789")
-      assert_style("55333.22", "55_333.22")
-      assert_style("-123456728.0001", "-123_456_728.0001")
+      assert_style("10000", "10_000", enable: :single_node)
+      assert_style("1_0_0_0_0", "10_000", enable: :single_node)
+      assert_style("-543213", "-543_213", enable: :single_node)
+      assert_style("123456789", "123_456_789", enable: :single_node)
+      assert_style("55333.22", "55_333.22", enable: :single_node)
+      assert_style("-123456728.0001", "-123_456_728.0001", enable: :single_node)
     end
 
     test "stays away from small numbers, strings and science" do
@@ -288,8 +301,8 @@ defmodule Styler.Style.SingleNodeTest do
 
   describe "Enum.into and $collectable.new" do
     test "into an empty map" do
-      assert_style("Enum.into(a, %{})", "Map.new(a)")
-      assert_style("Enum.into(a, %{}, mapper)", "Map.new(a, mapper)")
+      assert_style("Enum.into(a, %{})", "Map.new(a)", enable: :single_node)
+      assert_style("Enum.into(a, %{}, mapper)", "Map.new(a, mapper)", enable: :single_node)
     end
 
     test "into a collectable" do
@@ -297,15 +310,15 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("Enum.into(a, foo, mapper)")
 
       for collectable <- ~W(Map Keyword MapSet), new = "#{collectable}.new" do
-        assert_style("Enum.into(a, #{new})", "#{new}(a)")
-        assert_style("Enum.into(a, #{new}, mapper)", "#{new}(a, mapper)")
+        assert_style("Enum.into(a, #{new})", "#{new}(a)", enable: :single_node)
+        assert_style("Enum.into(a, #{new}, mapper)", "#{new}(a, mapper)", enable: :single_node)
       end
     end
   end
 
   describe "Enum.reverse/1 and ++" do
     test "optimizes into `Enum.reverse/2`" do
-      assert_style("Enum.reverse(foo) ++ bar", "Enum.reverse(foo, bar)")
+      assert_style("Enum.reverse(foo) ++ bar", "Enum.reverse(foo, bar)", enable: :single_node)
       assert_style("Enum.reverse(foo, bar) ++ bar")
     end
   end

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -14,7 +14,7 @@ defmodule Styler.Style.StylesTest do
   """
   use Styler.StyleCase, async: true
 
-  describe "pipes + defs" do
+  describe "pipes + defs + single_node" do
     test "pipes doesnt abuse meta and break defs" do
       assert_style(
         """
@@ -31,7 +31,8 @@ defmodule Styler.Style.StylesTest do
             :bop
           end
         end)
-        """
+        """,
+        enable: [:pipes, :defs, :single_node]
       )
     end
   end


### PR DESCRIPTION
An expression along the lines of `|> then(&(&1 * 2 / 1))` is currently being formatted as `|> (&1 * 2)` because the pattern match for single-arity functions is a bit too lax.

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!
