### PR TITLE
Fix piped `then` for complex expressions with division by one

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -189,7 +189,7 @@ defmodule Styler.Style.Pipes do
 
   # a |> then(&fun/1) |> c => a |> fun() |> c()
   # recurses to add the `()` to `fun` as it gets unwound
-  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [fun, {:__block__, _, [1]}]}]}]}]}),
+  defp fix_pipe({:|>, m, [lhs, {:then, _, [{:&, _, [{:/, _, [{_, _, nil} = fun, {:__block__, _, [1]}]}]}]}]}),
     do: fix_pipe({:|>, m, [lhs, fun]})
 
   # Credo.Check.Readability.PipeIntoAnonymousFunctions

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -501,6 +501,7 @@ defmodule Styler.Style.PipesTest do
     test "rewrites then/2 when the passed function is a named function reference" do
       assert_style "a |> then(&fun/1) |> c", "a |> fun() |> c()"
       assert_style "a |> then(&(&1 / 1)) |> c", "a |> Kernel./(1) |> c()"
+      assert_style "a |> then(&(&1 * 2 / 1)) |> c()"
       assert_style "a |> then(&fun/1)", "fun(a)"
       assert_style "a |> then(&fun(&1)) |> c", "a |> fun() |> c()"
       assert_style "a |> then(&fun(&1, d)) |> c", "a |> fun(d) |> c()"


### PR DESCRIPTION
An expression along the lines of `|> then(&(&1 * 2 / 1))` is currently being formatted as `|> (&1 * 2)` because the pattern match for single-arity functions is a bit too lax.

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!