### PR TITLE
Remove implicit try rule

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -39,12 +39,15 @@ Modules directives are sorted into the following order:
 
 * `@shortdoc`
 * `@moduledoc` (adds `@moduledoc false`)
-* `@behaviour`
 * `use`
 * `import` (sorted alphabetically)
 * `alias` (sorted alphabetically)
 * `require` (sorted alphabetically)
+* `@behaviour`
 * everything else (order unchanged)
+
+The heuristic here is that docs generally go first, followed by directives in order from most impactful on the module to
+least impactful on the module.
 
 ### Before
 
@@ -98,8 +101,6 @@ defmodule Foo do
              |> File.read!()
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
-  @behaviour Chaotic
-  @behaviour Lawful
 
   use B
   use A.A
@@ -107,13 +108,16 @@ defmodule Foo do
   import A.A
   import C
 
+  require A
+  require B
+  require C
+
   alias A.A
   alias C.C
   alias D.D
 
-  require A
-  require B
-  require C
+  @behaviour Chaotic
+  @behaviour Lawful
 
   def c(x), do: y
 
@@ -136,6 +140,7 @@ If any line previously relied on an alias, the alias is fully expanded when it i
 # Given
 alias Foo.Bar
 import Bar
+
 # Styled
 import Foo.Bar
 

--- a/lib/alias_env.ex
+++ b/lib/alias_env.ex
@@ -14,6 +14,7 @@ defmodule Styler.AliasEnv do
 
       %{:Bar => [:Foo, :Bar]}
   """
+
   def define(env \\ %{}, ast)
 
   def define(env, asts) when is_list(asts), do: Enum.reduce(asts, env, &define(&2, &1))

--- a/lib/style.ex
+++ b/lib/style.ex
@@ -31,7 +31,7 @@ defmodule Styler.Style do
   """
   @callback run(Zipper.t(), context()) :: {Zipper.command(), Zipper.t(), context()}
 
-  @doc "Recursively sets `:line` meta to `line`. Deletes `:newlines` unless `delete_lines: false` is passed"
+  @doc "Recursively sets `:line` meta to `line`. Deletes `:newlines` unless `delete_newlines: false` is passed"
   def set_line(ast_node, line, opts \\ []) do
     set_line = fn _ -> line end
 

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -33,11 +33,11 @@ defmodule Styler.Style.ModuleDirectives do
 
     * `@shortdoc`
     * `@moduledoc`
-    * `@behaviour`
     * `use`
     * `import`
-    * `alias`
     * `require`
+    * `alias`
+    * `@behaviour`
     * everything else (unchanged)
   """
 
@@ -49,9 +49,6 @@ defmodule Styler.Style.ModuleDirectives do
 
   @directives ~w(alias import require use)a
   @attr_directives ~w(moduledoc shortdoc behaviour)a
-  @defstruct ~w(schema embedded_schema defstruct)a
-
-  @moduledoc_false {:@, [line: nil], [{:moduledoc, [line: nil], [{:__block__, [line: nil], [false]}]}]}
 
   def run({{:defmodule, _, children}, _} = zipper, ctx) do
     [name, [{{:__block__, do_meta, [:do]}, _body}]] = children
@@ -105,41 +102,7 @@ defmodule Styler.Style.ModuleDirectives do
     end
   end
 
-  # puts `@derive` before `defstruct` etc, fixing compiler warnings
-  def run({{:@, _, [{:derive, _, _}]}, _} = zipper, ctx) do
-    case Style.ensure_block_parent(zipper) do
-      {:ok, {derive, %{l: left_siblings} = z_meta}} ->
-        previous_defstruct =
-          left_siblings
-          |> Stream.with_index()
-          |> Enum.find_value(fn
-            {{struct_def, meta, _}, index} when struct_def in @defstruct -> {meta[:line], index}
-            _ -> nil
-          end)
-
-        if previous_defstruct do
-          {defstruct_line, defstruct_index} = previous_defstruct
-          derive = Style.set_line(derive, defstruct_line - 1)
-          left_siblings = List.insert_at(left_siblings, defstruct_index + 1, derive)
-          {:skip, Zipper.remove({derive, %{z_meta | l: left_siblings}}), ctx}
-        else
-          {:cont, zipper, ctx}
-        end
-
-      :error ->
-        {:cont, zipper, ctx}
-    end
-  end
-
   def run(zipper, ctx), do: {:cont, zipper, ctx}
-
-  defp moduledoc({:__aliases__, m, aliases}) do
-    name = aliases |> List.last() |> to_string()
-    # module names ending with these suffixes will not have a default moduledoc appended
-    unless String.ends_with?(name, ~w(Test Mixfile MixProject Controller Endpoint Repo Router Socket View HTML JSON)) do
-      Style.set_line(@moduledoc_false, m[:line] + 1)
-    end
-  end
 
   # a dynamic module name, like `defmodule my_variable do ... end`
   defp moduledoc(_), do: nil
@@ -158,21 +121,14 @@ defmodule Styler.Style.ModuleDirectives do
     attr_lifts: []
   }
 
-  defp lift_module_attrs({node, _, _} = ast, %{attrs: attrs} = acc) do
+  defp lift_module_attrs({_node, _, _} = ast, %{attrs: attrs} = acc) do
     if Enum.empty?(attrs) do
       {ast, acc}
     else
-      use? = node == :use
-
       Macro.prewalk(ast, acc, fn
-        {:@, m, [{attr, _, _} = var]} = ast, acc ->
+        {:@, _m, [{attr, _, _} = var]} = ast, acc ->
           if attr in attrs do
-            replacement =
-              if use?,
-                do: {:unquote, [closing: [line: m[:line]], line: m[:line]], [var]},
-                else: var
-
-            {replacement, %{acc | attr_lifts: [attr | acc.attr_lifts]}}
+            {var, %{acc | attr_lifts: [attr | acc.attr_lifts]}}
           else
             {ast, acc}
           end
@@ -218,6 +174,7 @@ defmodule Styler.Style.ModuleDirectives do
         {k, v} -> {k, Enum.reverse(v)}
       end)
       |> lift_aliases()
+      |> Map.update!(:moduledoc, &Style.reset_newlines(&1))
 
     # Not happy with it, but this does the work to move module attribute assignments above the module or quote or whatever
     # Given that it'll only be run once and not again, i'm okay with it being inefficient
@@ -257,11 +214,11 @@ defmodule Styler.Style.ModuleDirectives do
       [
         acc.shortdoc,
         acc.moduledoc,
-        acc.behaviour,
         acc.use,
         acc.import,
+        acc.require,
         acc.alias,
-        acc.require
+        acc.behaviour
       ]
       |> Stream.concat()
       |> Style.fix_line_numbers(List.first(nondirectives))

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -40,6 +40,7 @@ defmodule Styler.Style.ModuleDirectives do
     * `require`
     * everything else (unchanged)
   """
+
   @behaviour Styler.Style
 
   alias Styler.AliasEnv

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -165,12 +165,9 @@ defmodule Styler.Style.SingleNode do
   defp style({def, dm, [{fun, funm, []} | rest]}) when def in ~w(def defp)a and is_atom(fun),
     do: style({def, dm, [{fun, Keyword.delete(funm, :closing), nil} | rest]})
 
-  # `Credo.Check.Readability.PreferImplicitTry`
-  defp style({def, dm, [head, [{_, {:try, _, [try_children]}}]]}) when def in ~w(def defp)a,
-    do: style({def, dm, [head, try_children]})
-
-  defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a,
-    do: {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}
+  defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a do
+    {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}
+  end
 
   # `Enum.reverse(foo) ++ bar` => `Enum.reverse(foo, bar)`
   defp style({:++, _, [{{:., _, [{_, _, [:Enum]}, :reverse]} = reverse, r_meta, [lhs]}, rhs]}),

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -221,12 +221,33 @@ defmodule Styler.Style.SingleNode do
     end)
   end
 
-  defp delimit(token), do: token |> String.to_charlist() |> remove_underscores([]) |> add_underscores([])
+  defp delimit(token) do
+    chars = String.to_charlist(token)
+
+    result =
+      case Enum.reverse(chars) do
+        [hundredth, tenth, ?_ | rest] when is_integer(tenth) and is_integer(hundredth) ->
+          delimited = rest |> Enum.reverse() |> fix_underscores()
+
+          delimited ++ [?_, tenth, hundredth]
+
+        _other_num ->
+          fix_underscores(chars)
+      end
+
+    to_string(result)
+  end
+
+  defp fix_underscores(num_tokens) do
+    num_tokens
+    |> remove_underscores([])
+    |> add_underscores([])
+  end
 
   defp remove_underscores([?_ | rest], acc), do: remove_underscores(rest, acc)
   defp remove_underscores([digit | rest], acc), do: remove_underscores(rest, [digit | acc])
   defp remove_underscores([], reversed_list), do: reversed_list
 
   defp add_underscores([a, b, c, d | rest], acc), do: add_underscores([d | rest], [?_, c, b, a | acc])
-  defp add_underscores(reversed_list, acc), do: reversed_list |> Enum.reverse(acc) |> to_string()
+  defp add_underscores(reversed_list, acc), do: Enum.reverse(reversed_list, acc)
 end

--- a/lib/style_error.ex
+++ b/lib/style_error.ex
@@ -12,6 +12,7 @@ defmodule Styler.StyleError do
   @moduledoc """
   Wraps errors raised by Styles during tree traversal.
   """
+
   defexception [:exception, :style, :file]
 
   def message(%{exception: exception, style: style, file: file}) do

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -12,6 +12,7 @@ defmodule Styler do
   @moduledoc """
   Styler is a formatter plugin with stronger opinions on code organization, multi-line defs and other code-style matters.
   """
+
   @behaviour Mix.Tasks.Format
 
   alias Mix.Tasks.Format

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -10,6 +10,7 @@
 
 defmodule Styler.Config do
   @moduledoc false
+
   @key __MODULE__
 
   @stdlib MapSet.new(~w(

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -23,6 +23,7 @@ defmodule Styler.Zipper do
   2-tuple where the first element is the focus and the second element is the
   metadata/context. The metadata is `nil` when the focus is the topmost node
   """
+
   import Kernel, except: [node: 1]
 
   @type tree :: Macro.t()

--- a/test/style/configs_test.exs
+++ b/test/style/configs_test.exs
@@ -10,6 +10,7 @@
 
 defmodule Styler.Style.ConfigsTest do
   @moduledoc false
+
   use Styler.StyleCase, async: true, filename: "config/config.exs"
 
   alias Styler.Style.Configs

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -83,11 +83,9 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
-        alias A.B.C
-
         defmodule B do
-          @moduledoc false
+          alias A.B.C
+
           C.f()
           C.f()
         end
@@ -110,14 +108,13 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule Timely do
-        @moduledoc false
         use A.B.C
 
         import A.B.C
 
-        alias A.B.C
-
         require C
+
+        alias A.B.C
 
         def foo do
           C.bop()
@@ -155,30 +152,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
     )
   end
 
-  test "lifts in modules with only-child bodies" do
-    assert_style(
-      """
-      defmodule A do
-        def lift_me() do
-          A.B.C.foo()
-          A.B.C.baz()
-        end
-      end
-      """,
-      """
-      defmodule A do
-        @moduledoc false
-        alias A.B.C
-
-        def lift_me do
-          C.foo()
-          C.baz()
-        end
-      end
-      """
-    )
-  end
-
   test "re-sorts requires after lifting" do
     assert_style(
       """
@@ -191,11 +164,10 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
-        alias A.B.C
-
         require B
         require C
+
+        alias A.B.C
 
         C.foo()
       end
@@ -235,9 +207,10 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
         A.B.C.f()
         """,
         """
-        alias A.B.C
         # Foo is my fave
         require Foo
+
+        alias A.B.C
 
         C.f()
         C.f()
@@ -320,6 +293,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
 
         defmodule C do
           @moduledoc false
+
           A.B.C.f()
         end
 
@@ -376,6 +350,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
 
         defmodule A.B.C do
           @moduledoc false
+
           :body
         end
 
@@ -400,6 +375,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       assert_style """
       defmodule A do
         @moduledoc false
+
         defmacro __using__(_) do
           quote do
             A.B.C.f()

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -10,6 +10,7 @@
 
 defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
   @moduledoc false
+
   use Styler.StyleCase, async: true
 
   test "lifts aliases repeated >=2 times from 3 deep" do

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -10,6 +10,7 @@
 
 defmodule Styler.Style.ModuleDirectivesTest do
   @moduledoc false
+
   use Styler.StyleCase, async: true
 
   describe "defmodule features" do

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -34,125 +34,14 @@ defmodule Styler.Style.ModuleDirectivesTest do
     test "module with single child" do
       assert_style(
         """
-        defmodule ATest do
+        defmodule A do
           alias Foo.{A, B}
         end
         """,
         """
-        defmodule ATest do
+        defmodule A do
           alias Foo.A
           alias Foo.B
-        end
-        """
-      )
-    end
-
-    test "adds moduledoc" do
-      assert_style(
-        """
-        defmodule A do
-        end
-        """,
-        """
-        defmodule A do
-          @moduledoc false
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule B do
-          defmodule C do
-          end
-        end
-        """,
-        """
-        defmodule B do
-          @moduledoc false
-          defmodule C do
-            @moduledoc false
-          end
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule Bar do
-          alias Bop.Bop
-
-          :ok
-        end
-        """,
-        """
-        defmodule Bar do
-          @moduledoc false
-          alias Bop.Bop
-
-          :ok
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule DocsOnly do
-          @moduledoc "woohoo"
-        end
-        """,
-        """
-        defmodule DocsOnly do
-          @moduledoc "woohoo"
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule Foo do
-          use Bar
-        end
-        """,
-        """
-        defmodule Foo do
-          @moduledoc false
-          use Bar
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule Foo do
-          alias Foo.{Bar, Baz}
-        end
-        """,
-        """
-        defmodule Foo do
-          @moduledoc false
-          alias Foo.Bar
-          alias Foo.Baz
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule A do
-          defmodule B do
-            :literal
-          end
-
-        end
-        """,
-        """
-        defmodule A do
-          @moduledoc false
-          defmodule B do
-            @moduledoc false
-            :literal
-          end
         end
         """
       )
@@ -221,8 +110,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
                      |> File.read!()
                      |> String.split("<!-- MDOC !-->")
                      |> Enum.fetch!(1)
-          @behaviour Chaotic
-          @behaviour Lawful
 
           use B
           use A.A
@@ -230,13 +117,16 @@ defmodule Styler.Style.ModuleDirectivesTest do
           import A.A
           import C
 
+          require A
+          require B
+          require C
+
           alias A.A
           alias C.C
           alias D.D
 
-          require A
-          require B
-          require C
+          @behaviour Chaotic
+          @behaviour Lawful
 
           def c(x), do: y
 
@@ -263,6 +153,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
       assert_style("""
       defmodule Foo do
         @moduledoc false
+
         @spec import(any(), any(), any()) :: any()
         def import(a, b, c), do: nil
       end
@@ -403,13 +294,13 @@ defmodule Styler.Style.ModuleDirectivesTest do
         alias A.A
         """,
         """
+        require A.A
+        require A.C
+
         alias A.A
         alias A.B
         alias B.B
         alias D.D
-
-        require A.A
-        require A.C
 
         @type foo :: :ok
         """
@@ -433,6 +324,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule Foo do
           # mdf
           @moduledoc false
+
           # B
           alias B.B
 
@@ -451,7 +343,9 @@ defmodule Styler.Style.ModuleDirectivesTest do
         defmodule Foo do
           # mdf
           @moduledoc false
+
           alias A.A
+
           # B
           alias B.B
           alias C.C
@@ -505,38 +399,12 @@ defmodule Styler.Style.ModuleDirectivesTest do
       require D
       """,
       """
+      require D
+
       alias A.A
       alias B.B
-
-      require D
       """
     )
-  end
-
-  test "@derive movements" do
-    assert_style(
-      """
-      defmodule F do
-        defstruct [:a]
-        # comment for foo
-        def foo, do: :ok
-        @derive Inspect
-        @derive {Foo, bar: :baz}
-      end
-      """,
-      """
-      defmodule F do
-        @moduledoc false
-        @derive Inspect
-        @derive {Foo, bar: :baz}
-        defstruct [:a]
-        # comment for foo
-        def foo, do: :ok
-      end
-      """
-    )
-
-    assert_style "@derive Inspect"
   end
 
   test "de-aliases use/behaviour/import/moduledoc" do
@@ -558,7 +426,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
       """
       defmodule MyModule do
         @moduledoc "Implements \#{A.B.C.foo()}!"
-        @behaviour G.H.C
 
         use SomeMacro, with: Z.X.C
 
@@ -570,6 +437,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         alias D.F.C
         alias G.H.C
         alias Z.X.C
+
+        @behaviour G.H.C
       end
       """
     )
@@ -590,34 +459,73 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
         defmodule MyGreatLibrary do
           @moduledoc make_pretty_docs(library_options)
-          use OptionsMagic, my_opts: unquote(library_options)
+
+          use OptionsMagic, my_opts: library_options
 
           @library_options library_options
         end
         """
       )
     end
+  end
 
-    test "works with `quote`" do
-      assert_style(
-        """
-        quote do
-          @library_options [...]
-          @moduledoc make_pretty_docs(@library_options)
-          use OptionsMagic, my_opts: @library_options
+  test "always adds a newline after moduledocs" do
+    assert_style(
+      """
+      defmodule A do
+        @moduledoc \"""
+        Hi there, I'm a module!
+        \"""
+        use Oban.Pro.Worker
+
+        alias BTest.Nested
+        def stuff do
+          Nested.call()
         end
-        """,
-        """
-        library_options = [...]
+      end
+      """,
+      """
+      defmodule A do
+        @moduledoc \"""
+        Hi there, I'm a module!
+        \"""
 
-        quote do
-          @moduledoc make_pretty_docs(library_options)
-          use OptionsMagic, my_opts: unquote(library_options)
+        use Oban.Pro.Worker
 
-          @library_options library_options
+        alias BTest.Nested
+
+        def stuff do
+          Nested.call()
         end
-        """
-      )
-    end
+      end
+      """
+    )
+
+    assert_style(
+      """
+      defmodule A do
+        @moduledoc false
+        use Oban.Pro.Worker
+
+        alias BTest.Nested
+        def stuff do
+          Nested.call()
+        end
+      end
+      """,
+      """
+      defmodule A do
+        @moduledoc false
+
+        use Oban.Pro.Worker
+
+        alias BTest.Nested
+
+        def stuff do
+          Nested.call()
+        end
+      end
+      """
+    )
   end
 end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -301,11 +301,11 @@ defmodule Styler.Style.SingleNodeTest do
     end
 
     test "if the last two numbers separated by an underscore, leave those" do
-      assert_style("10_00", "10_00")
-      assert_style("10000_00", "10_000_00")
-      assert_style("97_8", "97_8")
       assert_style("1_00", "1_00")
-      assert_style("1000_99", "1_000_99")
+      assert_style("10_00", "10_00")
+      assert_style("97_8", "97_8")
+      assert_style("18000_76", "18_000_76")
+      assert_style("1020000_99", "1_020_000_99")
     end
 
     test "stays away from small numbers, strings and science" do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -141,6 +141,19 @@ defmodule Styler.Style.SingleNodeTest do
         assert_style(
           """
           #{def_style} foo() do
+            :ok
+          rescue
+            exception -> :excepted
+          catch
+            :a_throw -> :thrown
+          else
+            i_forgot -> i_forgot.this_could_happen
+          after
+            :done
+          end
+          """,
+          """
+          #{def_style} foo do
             try do
               :ok
             rescue
@@ -152,19 +165,6 @@ defmodule Styler.Style.SingleNodeTest do
             after
               :done
             end
-          end
-          """,
-          """
-          #{def_style} foo do
-            :ok
-          rescue
-            exception -> :excepted
-          catch
-            :a_throw -> :thrown
-          else
-            i_forgot -> i_forgot.this_could_happen
-          after
-            :done
           end
           """
         )

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -300,6 +300,14 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("-123456728.0001", "-123_456_728.0001")
     end
 
+    test "if the last two numbers separated by an underscore, leave those" do
+      assert_style("10_00", "10_00")
+      assert_style("10000_00", "10_000_00")
+      assert_style("97_8", "97_8")
+      assert_style("1_00", "1_00")
+      assert_style("1000_99", "1_000_99")
+    end
+
     test "stays away from small numbers, strings and science" do
       assert_style("1234")
       assert_style("9999")

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -300,7 +300,7 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("-123456728.0001", "-123_456_728.0001")
     end
 
-    test "if the last two numbers separated by an underscore, leave those" do
+    test "if the last two numbers are separated by an underscore (cents style), leave the cents style in place" do
       assert_style("1_00", "1_00")
       assert_style("10_00", "10_00")
       assert_style("97_8", "97_8")

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -12,6 +12,7 @@ defmodule Styler.Style.StylesTest do
   @moduledoc """
   A place for tests that make sure our styles play nicely with each other
   """
+
   use Styler.StyleCase, async: true
 
   describe "pipes + defs" do

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -12,6 +12,7 @@ defmodule Styler.StyleCase do
   @moduledoc """
   Helpers around testing Style rules.
   """
+
   use ExUnit.CaseTemplate
 
   using options do


### PR DESCRIPTION
We like using `try` explicitly since `try` use should be obvious and rare.