### PR TITLE
ci: update elixir and erlang versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     name: Ex${{matrix.elixir}}/OTP${{matrix.otp}}
     strategy:
       matrix:
-        elixir: ['1.15.7', '1.16.0', '1.17.0-rc.0']
-        otp: ['25.1.2']
+        elixir: ['1.15.8', '1.16.3', '1.17.3']
+        otp: ['25.3.2']
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!

@novaugust how about updating the matrix, dropping Elixir 1.15 in favour of Erlang 26?