### PR TITLE
pipes: handle pipifying functions whose first arg is itself a pipe. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This release taught Styler to try just that little bit harder when doing alias l
         C.bar()
         C.baz()
 
+### Fixes
+
+- `pipes`: handle pipifying when the first arg is itself a pipe: `c(a |> b, d)` => `a |> b() |> c(d)` (#213, h/t @kybishop)
 
 ## 1.3.3
 

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -370,9 +370,16 @@ defmodule Styler.Style.ModuleDirectives do
                       # - required: its first comes _after_ last, so we aren't promoting an alias that changes the meaning of the other alias we're doing
                       # - preferred: take a collider we know we want to lift (we've seen it multiple times)
                       lift =
-                        Enum.find(colliders, fn {[first | _], seen?} -> seen? and first > last end) ||
-                          Enum.find(colliders, fn {[first | _], _} -> first > last end) ||
-                          :collision_with_first
+                        Enum.reduce_while(colliders, :collision_with_first, fn
+                          {[first | _], true} = liftable, _ when first > last ->
+                            {:halt, liftable}
+
+                          {[first | _], _false} = promotable, :collision_with_first when first > last ->
+                            {:cont, promotable}
+
+                          _, result ->
+                            {:cont, result}
+                        end)
 
                       Map.put(lifts, first, lift)
 

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -168,7 +168,10 @@ defmodule Styler.Style.Pipes do
         {:cont, zipper, ctx}
 
       true ->
-        {:cont, Zipper.replace(zipper, {:|>, m, [pipe, {f, m, args}]}), ctx}
+        # Recurse in case the function-looking is a multi pipe
+        zipper
+        |> Zipper.replace({:|>, m, [pipe, {f, m, args}]})
+        |> run(ctx)
     end
   end
 

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -934,6 +934,9 @@ defmodule Styler.Style.PipesTest do
       assert_style ~s<"\#{#{pipe}}">
     end
 
+    test "pipifying pipes" do
+    end
+
     test "when it's not actually the first argument!" do
       assert_style """
       a
@@ -944,6 +947,7 @@ defmodule Styler.Style.PipesTest do
 
     test "pipifying" do
       assert_style "d(a |> b |> c)", "a |> b() |> c() |> d()"
+      assert_style("c(a |> b, d)", "a |> b() |> c(d)")
 
       assert_style(
         """


### PR DESCRIPTION
closes #193 