### PR TITLE
Add OTP26/27 but only run for 1.17/1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,13 @@ jobs:
     name: Ex${{matrix.elixir}}/OTP${{matrix.otp}}
     strategy:
       matrix:
-        elixir: ['1.15.8', '1.16.3', '1.17.3', '1.18.2']
-        otp: ['25.3.2']
+        elixir: ["1.15.8", "1.16.3", "1.17.3", "1.18.2"]
+        otp: ["25.3.2", "26.2.5", "27.2.4"]
+        exclude:
+          - elixir: "1.15.8"
+            otp: "27.2.4"
+          - elixir: "1.16.3"
+            otp: "27.2.4"
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!

Add OTP26/27 to the matrix as 1.17/1.18 support them by default.

Exclude OTP27 for 1.15/1.16