### PR TITLE
Fix adding a newline character after @moduledoc

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -63,6 +63,7 @@ defmodule Foo do
              |> File.read!()
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
+
   @behaviour Chaotic
   @behaviour Lawful
 
@@ -217,3 +218,47 @@ This Style is not applied if the module's name ends with one of the following (t
 * `View`
 * `HTML`
 * `JSON`
+
+## Moduledoc Spacing
+
+Styler ensures consistent spacing after `@moduledoc` by adding a blank line when the moduledoc is followed by directives or attributes. This improves code readability and consistency with common Elixir formatting patterns.
+
+### Before
+
+```elixir
+defmodule MyModule do
+  @moduledoc "This module does something useful"
+  @behaviour GenServer
+  use OtherModule
+  alias SomeModule
+  
+  def start_link(opts) do
+    # ...
+  end
+end
+```
+
+### After
+
+```elixir
+defmodule MyModule do
+  @moduledoc "This module does something useful"
+
+  @behaviour GenServer
+
+  use OtherModule
+
+  alias SomeModule
+
+  def start_link(opts) do
+    # ...
+  end
+end
+```
+
+The blank line is added after `@moduledoc` when it's followed by:
+- Other module attributes like `@behaviour`, `@derive`, `@spec`, etc.
+- Directives like `use`, `import`, `alias`, `require`
+- Functions and other module content
+
+No blank line is added when `@moduledoc` is only followed by nested `defmodule` statements, as this would create unnecessary spacing in namespace modules.

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -147,6 +147,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule A do
         @moduledoc false
+
         alias A.B.C
 
         defmodule B do
@@ -174,6 +175,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule Timely do
         @moduledoc false
+
         use A.B.C
 
         import A.B.C
@@ -231,6 +233,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule A do
         @moduledoc false
+
         alias A.B.C
 
         def lift_me do
@@ -255,6 +258,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule A do
         @moduledoc false
+
         alias A.B.C
 
         require B

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -87,6 +87,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """
         defmodule Bar do
           @moduledoc false
+
           alias Bop.Bop
 
           :ok
@@ -116,6 +117,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """
         defmodule Foo do
           @moduledoc false
+
           use Bar
         end
         """
@@ -130,6 +132,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """
         defmodule Foo do
           @moduledoc false
+
           alias Foo.Bar
           alias Foo.Baz
         end
@@ -220,6 +223,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
                      |> File.read!()
                      |> String.split("<!-- MDOC !-->")
                      |> Enum.fetch!(1)
+
           @behaviour Chaotic
           @behaviour Lawful
 
@@ -262,6 +266,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
       assert_style("""
       defmodule Foo do
         @moduledoc false
+
         @spec import(any(), any(), any()) :: any()
         def import(a, b, c), do: nil
       end
@@ -574,6 +579,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
       """
       defmodule MyModule do
         @moduledoc "Implements \#{A.B.C.foo()}!"
+
         @behaviour G.H.C
 
         use SomeMacro, with: Z.X.C
@@ -606,6 +612,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
         defmodule MyGreatLibrary do
           @moduledoc make_pretty_docs(library_options)
+
           use OptionsMagic, my_opts: unquote(library_options)
 
           @library_options library_options
@@ -628,6 +635,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
         quote do
           @moduledoc make_pretty_docs(library_options)
+
           use OptionsMagic, my_opts: unquote(library_options)
 
           @library_options library_options


### PR DESCRIPTION
Meant to fix https://github.com/adobe/elixir-styler/issues/104

Update: 
Apologies. I meant to fork the repo and create a PR into my own fork. I didn't mean to point back to the official `elixir-styler` repo. 

I'm fairly new to the elixir world and have been using claude code recently and thought I'd take a stab at trying to fix the styler to add new lines. I don't know if the implementation for adding a new line after the `@moduledoc` conforms to what is expected, but this does work now. 