### PR TITLE
Add support for negated comparisons

### DIFF
--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -41,6 +41,11 @@ defmodule Styler.Style.SingleNode do
   # refute nilly -> assert
   defp style({:refute, meta, [{:is_nil, _, [x]}]}), do: style({:assert, meta, [x]})
   defp style({:refute, meta, [{:==, _, [x, {:__block__, _, [nil]}]}]}), do: style({:assert, meta, [x]})
+
+  # negated comparisons
+  defp style({:not, _, [{:==, m, xy}]}), do: {:!=, m, xy}
+  defp style({:!, _, [{:==, m, xy}]}), do: {:!=, m, xy}
+
   # boolean ops and assert hurt my brain.
   # the lone exception is `==` (... for now) ((uh, and the exception to the exception is when it's `== nil`, above))
   defp style({:refute, meta, [{:!=, m, xy}]}), do: style({:assert, meta, [{:==, m, xy}]})

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -67,6 +67,12 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style "refute x > y", "assert x <= y"
       assert_style "refute x >= y", "assert x < y"
     end
+
+    test "negated comparisons" do
+      assert_style "not (x == y)", "x != y"
+      assert_style "!(x == y)", "x != y"
+      assert_style "x != y"
+    end
   end
 
   test "string sigil rewrites" do


### PR DESCRIPTION
We add support for the following patterns:
* `not (a == b)` => `a != b`
* `!(a == b)` => `a != b`

Resolves #250

- [x] Please [sign Adobe's CLA](http://opensource.adobe.com/cla.html) if this is your first time contributing to an Adobe open source repo. Thanks!
